### PR TITLE
[Feat] 참여기록 페이지 UI 구현

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,10 +1,11 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
 import CreatePostForm from "@/components/organisms/CreatePostForm";
 
 function CreateHome() {
   return (
-    <div className="mt-8 p-16 bg-white lg:mx-28">
+    <BackArrowContainer>
       <CreatePostForm />
-    </div>
+    </BackArrowContainer>
   );
 }
 

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,3 +1,4 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
 import PostTemplates from "@/components/templates/PostTemplates";
 import React from "react";
 
@@ -9,9 +10,9 @@ interface Props {
 
 function PostHome({ params }: Props) {
   return (
-    <div className="mt-8 p-16 bg-white lg:mx-28">
+    <BackArrowContainer>
       <PostTemplates id={params.id} />
-    </div>
+    </BackArrowContainer>
   );
 }
 

--- a/src/app/scoreboard/[user_id]/page.tsx
+++ b/src/app/scoreboard/[user_id]/page.tsx
@@ -1,0 +1,12 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
+import ScoreboardTemplate from "@/components/templates/ScoreboardTemplate";
+
+function ScoreboardPage() {
+  return (
+    <BackArrowContainer>
+      <ScoreboardTemplate />
+    </BackArrowContainer>
+  );
+}
+
+export default ScoreboardPage;

--- a/src/components/atoms/BackArrowButton/index.tsx
+++ b/src/components/atoms/BackArrowButton/index.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { MdArrowBack } from "react-icons/md";
+
+function BackArrowButton() {
+  const router = useRouter();
+  const handleBack = () => {
+    router.refresh();
+    router.push("/");
+  };
+  return <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />;
+}
+
+export default BackArrowButton;

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from "next/navigation";
+import { MdArrowBack } from "react-icons/md";
+
+function BackArrowContainer() {
+  const router = useRouter();
+  const handleBack = () => {
+    router.refresh();
+    router.push("/");
+  };
+  return (
+    <div className="mt-8 p-16 bg-white lg:mx-28">
+      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
+    </div>
+  );
+}
+
+export default BackArrowContainer;

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useRouter } from "next/navigation";
 import { MdArrowBack } from "react-icons/md";
 

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -1,21 +1,13 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-import { MdArrowBack } from "react-icons/md";
+import BackArrowButton from "../BackArrowButton";
 
 interface Props {
   children: React.ReactNode;
 }
 
 function BackArrowContainer({ children }: Props) {
-  const router = useRouter();
-  const handleBack = () => {
-    router.refresh();
-    router.push("/");
-  };
   return (
     <div className="mt-8 p-16 bg-white lg:mx-28">
-      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
+      <BackArrowButton />
       {children}
     </div>
   );

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -3,7 +3,11 @@
 import { useRouter } from "next/navigation";
 import { MdArrowBack } from "react-icons/md";
 
-function BackArrowContainer() {
+interface Props {
+  children: React.ReactNode;
+}
+
+function BackArrowContainer({ children }: Props) {
   const router = useRouter();
   const handleBack = () => {
     router.refresh();
@@ -12,6 +16,7 @@ function BackArrowContainer() {
   return (
     <div className="mt-8 p-16 bg-white lg:mx-28">
       <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
+      {children}
     </div>
   );
 }

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  styleType: "white" | "thunder" | "outlined-gray";
+  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
   rounded: "full" | "md";
   size: "lg" | "sm";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -12,6 +12,9 @@ function Button({ styleType, rounded, size, onClick, children, noLineHeight }: P
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
+    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white`,
+    "outlined-blue": `border-blue-400 text-blue-400 bg-white`,
+    "filled-blue": `text-white bg-blue-500`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -6,9 +6,19 @@ interface Props {
   children: React.ReactNode;
   noLineHeight?: boolean;
   fontWeight?: "bold" | "semibold" | "normal";
+  fontSize?: "sm" | "md" | "lg";
 }
 
-function Button({ styleType, rounded, size, onClick, children, noLineHeight, fontWeight = "bold" }: Props) {
+function Button({
+  styleType,
+  rounded,
+  size,
+  onClick,
+  children,
+  noLineHeight,
+  fontWeight = "bold",
+  fontSize = "md",
+}: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -30,13 +40,18 @@ function Button({ styleType, rounded, size, onClick, children, noLineHeight, fon
     semibold: "font-semibold",
     normal: "font-normal",
   };
+  const fontSizeObj = {
+    sm: "text-sm",
+    md: "text-base",
+    lg: "text-lg",
+  };
 
   return (
     <button
       type="button"
       className={`px-2 py-1 ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${
         roundedObj[rounded]
-      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${noLineHeight && "leading-none"}`}
+      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -28,8 +28,8 @@ function Button({
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
-    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white`,
-    "outlined-blue": `border-blue-400 text-blue-400 bg-white`,
+    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
+    "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
     "filled-blue": `text-white bg-blue-500`,
   };
   const sizeObj = {

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -19,16 +19,16 @@ function Button({ styleType, rounded, size, onClick, children, fontWeight = "bol
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
-    "thunder-w-20": "bg-thunder text-white min-w-[80px]",
-    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white min-w-[80px]",
-    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white min-w-[80px]`,
-    "outlined-blue": `border border-blue-400 text-blue-400 bg-white min-w-[80px]`,
-    "filled-blue": `border text-white bg-blue-500 min-w-[80px]`,
+    "thunder-w-20": "bg-thunder text-white",
+    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
+    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
+    "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
+    "filled-blue": `border text-white bg-blue-500`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",
     sm: "px-2 py-1",
-    xs: "px-2 py-[3px] leading-none text-sm",
+    xs: "px-2 py-[3px] leading-none text-sm min-w-[80px]",
   };
   const roundedObj = {
     full: "rounded-full",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,40 +1,34 @@
 export interface ButtonProps {
-  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
+  styleType:
+    | "white"
+    | "thunder"
+    | "thunder-w-20"
+    | "outlined-gray"
+    | "outlined-orange"
+    | "outlined-blue"
+    | "filled-blue";
   rounded: "full" | "md";
-  size: "lg" | "sm";
+  size: "lg" | "sm" | "xs";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
-  noLineHeight?: boolean;
   fontWeight?: "bold" | "semibold" | "normal";
-  fontSize?: "sm" | "md" | "lg";
-  padding?: "px-2_py-1" | "px-2_py-[3px]";
-  minWidth?: "70px";
 }
 
-function Button({
-  styleType,
-  rounded,
-  size,
-  onClick,
-  children,
-  noLineHeight,
-  fontWeight = "bold",
-  fontSize = "md",
-  padding = "px-2_py-1",
-  minWidth,
-}: ButtonProps) {
+function Button({ styleType, rounded, size, onClick, children, fontWeight = "bold" }: ButtonProps) {
   const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
-    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
-    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
-    "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
-    "filled-blue": `border text-white bg-blue-500`,
+    "thunder-w-20": "bg-thunder text-white min-w-[80px]",
+    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white min-w-[80px]",
+    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white min-w-[80px]`,
+    "outlined-blue": `border border-blue-400 text-blue-400 bg-white min-w-[80px]`,
+    "filled-blue": `border text-white bg-blue-500 min-w-[80px]`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",
-    sm: "",
+    sm: "px-2 py-1",
+    xs: "px-2 py-[3px] leading-none text-sm",
   };
   const roundedObj = {
     full: "rounded-full",
@@ -45,26 +39,11 @@ function Button({
     semibold: "font-semibold",
     normal: "font-normal",
   };
-  const fontSizeObj = {
-    sm: "text-sm",
-    md: "text-base",
-    lg: "text-lg",
-  };
-  const paddingObj = {
-    "px-2_py-1": "px-2 py-1",
-    "px-2_py-[3px]": "px-2 py-[3px]",
-  };
-  const minWidthObj = {
-    "70px": "min-w-[70px]",
-  };
 
   return (
     <button
       type="button"
-      className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${
-        fontWeightObj[fontWeight]
-      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${minWidth && minWidthObj[minWidth]} ${
-        noLineHeight && "leading-none"
+      className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${fontWeightObj[fontWeight]} 
       }`}
       onClick={onClick}
     >

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -4,9 +4,10 @@ interface Props {
   size: "lg" | "sm";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
+  noLineHeight?: boolean;
 }
 
-function Button({ styleType, rounded, size, onClick, children }: Props) {
+function Button({ styleType, rounded, size, onClick, children, noLineHeight }: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -24,7 +25,9 @@ function Button({ styleType, rounded, size, onClick, children }: Props) {
   return (
     <button
       type="button"
-      className={`px-2 py-1 ring-gray-400 ring-inset font-bold filter hover:brightness-95 ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]}`}
+      className={`px-2 py-1 ring-gray-400 ring-inset font-bold filter hover:brightness-95 ${styleObj[styleType]} ${
+        roundedObj[rounded]
+      } ${sizeObj[size]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -21,6 +21,7 @@ function Button({
   fontSize = "md",
   padding = "px-2_py-1",
 }: Props) {
+  const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -55,9 +56,9 @@ function Button({
   return (
     <button
       type="button"
-      className={`ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${roundedObj[rounded]} ${
-        sizeObj[size]
-      } ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
+      className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${
+        fontWeightObj[fontWeight]
+      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,4 +1,4 @@
-interface Props {
+export interface ButtonProps {
   styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
   rounded: "full" | "md";
   size: "lg" | "sm";
@@ -22,7 +22,7 @@ function Button({
   fontSize = "md",
   padding = "px-2_py-1",
   minWidth,
-}: Props) {
+}: ButtonProps) {
   const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -8,6 +8,7 @@ interface Props {
   fontWeight?: "bold" | "semibold" | "normal";
   fontSize?: "sm" | "md" | "lg";
   padding?: "px-2_py-1" | "px-2_py-[3px]";
+  minWidth?: "70px";
 }
 
 function Button({
@@ -20,6 +21,7 @@ function Button({
   fontWeight = "bold",
   fontSize = "md",
   padding = "px-2_py-1",
+  minWidth,
 }: Props) {
   const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
@@ -52,13 +54,18 @@ function Button({
     "px-2_py-1": "px-2 py-1",
     "px-2_py-[3px]": "px-2 py-[3px]",
   };
+  const minWidthObj = {
+    "70px": "min-w-[70px]",
+  };
 
   return (
     <button
       type="button"
       className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${
         fontWeightObj[fontWeight]
-      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
+      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${minWidth && minWidthObj[minWidth]} ${
+        noLineHeight && "leading-none"
+      }`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -30,7 +30,7 @@ function Button({
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
     "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
     "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
-    "filled-blue": `text-white bg-blue-500`,
+    "filled-blue": `border text-white bg-blue-500`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,12 +1,5 @@
 export interface ButtonProps {
-  styleType:
-    | "white"
-    | "thunder"
-    | "thunder-w-20"
-    | "outlined-gray"
-    | "outlined-orange"
-    | "outlined-blue"
-    | "filled-blue";
+  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
   rounded: "full" | "md";
   size: "lg" | "sm" | "xs";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -19,7 +12,6 @@ function Button({ styleType, rounded, size, onClick, children, fontWeight = "bol
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
-    "thunder-w-20": "bg-thunder text-white",
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
     "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
     "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -5,9 +5,10 @@ interface Props {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
   noLineHeight?: boolean;
+  fontWeight?: "bold" | "semibold" | "normal";
 }
 
-function Button({ styleType, rounded, size, onClick, children, noLineHeight }: Props) {
+function Button({ styleType, rounded, size, onClick, children, noLineHeight, fontWeight = "bold" }: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -24,13 +25,18 @@ function Button({ styleType, rounded, size, onClick, children, noLineHeight }: P
     full: "rounded-full",
     md: "rounded-md",
   };
+  const fontWeightObj = {
+    bold: "font-bold",
+    semibold: "font-semibold",
+    normal: "font-normal",
+  };
 
   return (
     <button
       type="button"
-      className={`px-2 py-1 ring-gray-400 ring-inset font-bold filter hover:brightness-95 ${styleObj[styleType]} ${
+      className={`px-2 py-1 ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${
         roundedObj[rounded]
-      } ${sizeObj[size]} ${noLineHeight && "leading-none"}`}
+      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -7,6 +7,7 @@ interface Props {
   noLineHeight?: boolean;
   fontWeight?: "bold" | "semibold" | "normal";
   fontSize?: "sm" | "md" | "lg";
+  padding?: "px-2_py-1" | "px-2_py-[3px]";
 }
 
 function Button({
@@ -18,6 +19,7 @@ function Button({
   noLineHeight,
   fontWeight = "bold",
   fontSize = "md",
+  padding = "px-2_py-1",
 }: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
@@ -45,13 +47,17 @@ function Button({
     md: "text-base",
     lg: "text-lg",
   };
+  const paddingObj = {
+    "px-2_py-1": "px-2 py-1",
+    "px-2_py-[3px]": "px-2 py-[3px]",
+  };
 
   return (
     <button
       type="button"
-      className={`px-2 py-1 ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${
-        roundedObj[rounded]
-      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${noLineHeight && "leading-none"}`}
+      className={`ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${roundedObj[rounded]} ${
+        sizeObj[size]
+      } ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/RecordSummary/index.tsx
+++ b/src/components/atoms/RecordSummary/index.tsx
@@ -1,17 +1,19 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 interface Props {
-  game: 20;
-  average: 160;
-  maximum: 180;
-  minimum: 110;
+  data: {
+    game: number;
+    average: number;
+    maximum: number;
+    minimum: number;
+  };
 }
-function RecordSummary({ game, average, maximum, minimum }: Props) {
+function RecordSummary({ data }: Props) {
   return (
     <div className="record-summary grid gap-[5%] grid-cols-2 md:grid-cols-4 sm">
-      <Card text="Game" number={game} />
-      <Card text="Average" number={average} />
-      <Card text="Maximum" number={maximum} />
-      <Card text="Minimum" number={minimum} />
+      <Card text="Game" number={data.game} />
+      <Card text="Average" number={data.average} />
+      <Card text="Maximum" number={data.maximum} />
+      <Card text="Minimum" number={data.minimum} />
     </div>
   );
 }

--- a/src/components/atoms/RecordSummary/index.tsx
+++ b/src/components/atoms/RecordSummary/index.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+interface Props {
+  game: 20;
+  average: 160;
+  maximum: 180;
+  minimum: 110;
+}
+function RecordSummary({ game, average, maximum, minimum }: Props) {
+  return (
+    <div className="record-summary grid gap-[5%] grid-cols-2 md:grid-cols-4 sm">
+      <Card text="Game" number={game} />
+      <Card text="Average" number={average} />
+      <Card text="Maximum" number={maximum} />
+      <Card text="Minimum" number={minimum} />
+    </div>
+  );
+}
+
+export default RecordSummary;
+
+function Card({ text, number }: { text: string; number: number }) {
+  return (
+    <div className="card relative min-h-[80px] rounded-md shadow-lg bg-white py-1 px-2">
+      <span className="text-sm leading-none">{text}</span>
+      <span className="text-xl font-semibold absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+        {number}
+      </span>
+    </div>
+  );
+}

--- a/src/components/molecules/MiniProfile/index.tsx
+++ b/src/components/molecules/MiniProfile/index.tsx
@@ -1,0 +1,19 @@
+import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import Link from "next/link";
+
+interface Prop {
+  userId: number;
+  imageSrc: string | null;
+  userName: string;
+}
+
+function MiniProfile({ userId, imageSrc, userName }: Prop) {
+  return (
+    <Link href={`/user_profile/${userId}`} className="inline-flex gap-1 items-center">
+      <CircularProfileImage src={imageSrc} />
+      <span className="user-name text-xl">{userName}</span>
+    </Link>
+  );
+}
+
+export default MiniProfile;

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -1,0 +1,5 @@
+function RecordCard() {
+  return <div>RecordCard</div>;
+}
+
+export default RecordCard;

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -43,12 +43,7 @@ function RecordCard({ data }: Props) {
         <RecordTimeWithLocation districtName={data.districtName} startTime={data.startTime} />
         <div className="scores">
           {scores.map((score) => (
-            <ScoreWithImageButton
-              key={`${data.id}:${score.id}`}
-              scoreId={score.id}
-              score={score.score}
-              scoreImage={score.scoreImage}
-            />
+            <ScoreWithImageButton key={`${data.id}:${score.id}`} scoreObj={score} />
           ))}
         </div>
         <div className="expand-button-with-member-image flex w-full justify-between items-center">
@@ -95,19 +90,11 @@ function RecordTimeWithLocation({ districtName, startTime }: { districtName: str
   );
 }
 
-function ScoreWithImageButton({
-  scoreId,
-  score,
-  scoreImage,
-}: {
-  scoreId: number;
-  score: number;
-  scoreImage: string | null;
-}) {
+function ScoreWithImageButton({ scoreObj }: { scoreObj: { id: number; score: number; scoreImage: string | null } }) {
   return (
     <div className="score flex gap-2">
-      <span>{`스코어 ${scoreId} | ${score}`}</span>
-      {scoreImage && (
+      <span>{`스코어 ${scoreObj.id} | ${scoreObj.score}`}</span>
+      {scoreObj.scoreImage && (
         <button
           type="button"
           className="inline-flex items-center gap-x-0.5 border border-thunderOrange text-thunderOrange text-sm rounded-full px-2 py-[3px] bg-white hover:brightness-95"

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -1,5 +1,148 @@
-function RecordCard() {
-  return <div>RecordCard</div>;
+"use client";
+
+import Badge from "@/components/atoms/Badge";
+import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import Participant from "@/components/atoms/Participant";
+import { RecordData } from "@/types/recordData";
+import { getCookie } from "@/utils/Cookie";
+import { formatDateToString } from "@/utils/formatDateToString";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
+
+interface Props {
+  data: RecordData;
+}
+
+function RecordCard({ data }: Props) {
+  const params = useParams();
+  const [isExpand, setIsExpand] = useState(false);
+
+  const members = data?.members;
+  const scores = data?.scores;
+  const myId = getCookie("userId");
+  const isMyRecord = myId === parseInt(params.user_id as string, 10);
+
+  return (
+    <div className="record-card flex flex-col gap-6 bg-white p-7 rounded-2xl shadow ">
+      <div className="record-card-upper">
+        <Badge isClose={data.isClose} />
+        <Participant currentNumber={data.currentNumber} />
+        <span className="text-neutral-400">
+          <span className="mr-1">모집마감</span>
+          <span>{formatDateToString(data.dueTime)}</span>
+        </span>
+      </div>
+      <Link href={`/post/${data.id}`} className="record-title-wrapper">
+        <h1 className="record-title text-2xl">{data.title}</h1>
+      </Link>
+      <div className="record-card-lower flex flex-col gap-2">
+        <div className="record-info-wrapper flex gap-4 text-neutral-400">
+          <p className="district-name">
+            <MdLocationPin className="inline" />
+            <span>{data.districtName}</span>
+          </p>
+          <p className="start-time">
+            <MdAlarm className="inline" />
+            <span>{formatDateToString(data.startTime)}</span>
+          </p>
+        </div>
+        <div className="scores">
+          {scores.map((score) => (
+            <div key={`${data.id}:${score.id}`} className="score flex gap-2">
+              <span>{`스코어 ${score.id} | ${score.score}`}</span>
+              {score.scoreImage && (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-x-0.5 border border-thunderOrange text-thunderOrange text-sm rounded-full px-2 py-[3px] bg-white hover:brightness-95"
+                >
+                  <MdCameraAlt className="inline" />
+                  <span className="leading-none">이미지 보기</span>
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="expand-button-with-member-image flex w-full justify-between items-center">
+          <div className="member-image-preview flex gap-2 items-center">
+            {!isExpand &&
+              (members.length > 3 ? (
+                <>
+                  {members.slice(0, 3).map((member) => (
+                    <CircularProfileImage key={member.id} src={member.profileImage} styleType="md" />
+                  ))}
+                  <MdMoreHoriz className="text-neutral-400 w-8 h-8" />
+                </>
+              ) : (
+                members.map((member) => (
+                  <CircularProfileImage key={member.id} src={member.profileImage} styleType="md" />
+                ))
+              ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setIsExpand((prev) => !prev);
+            }}
+          >
+            {isExpand ? (
+              <MdArrowDropUp className="h-12 w-12 hover:scale-125 transition" />
+            ) : (
+              <MdArrowDropDown className="h-12 w-12 hover:scale-125 transition" />
+            )}
+          </button>
+        </div>
+        {isExpand &&
+          (members.length ? (
+            <div className="members grid grid-cols-2 gap-2">
+              {members.map((member) => {
+                const commonButtonStyle =
+                  "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
+                const buttonStyles = {
+                  "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
+                  "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
+                  "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
+                  "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
+                };
+                return (
+                  <div key={`${data.id}:${member.id}`} className="member flex gap-4 items-center">
+                    <Link href={`/user_profile/${member.id}`} className="flex gap-1 items-center">
+                      <CircularProfileImage src={member.profileImage} />
+                      <span className="member-name text-xl">{member.name}</span>
+                    </Link>
+                    {isMyRecord &&
+                      myId === member.id &&
+                      (scores.length ? (
+                        <button type="button" className={buttonStyles["outlined-blue"]}>
+                          수정하기
+                        </button>
+                      ) : (
+                        <button type="button" className={buttonStyles["filled-blue"]}>
+                          점수등록
+                        </button>
+                      ))}
+                    {isMyRecord &&
+                      myId !== member.id &&
+                      (member.isRated ? (
+                        <button type="button" className={buttonStyles["outlined-gray"]}>
+                          완료
+                        </button>
+                      ) : (
+                        <button type="button" className={buttonStyles["outlined-orange"]}>
+                          별점주기
+                        </button>
+                      ))}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <span className="no-member text-center text-2xl text-neutral-400">참여자가 없습니다.</span>
+          ))}
+      </div>
+    </div>
+  );
 }
 
 export default RecordCard;

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -11,7 +11,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Dispatch, SetStateAction, useState } from "react";
 import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
-import MiniProfile from "../MiniProfile";
+import RecordCardMember from "../RecordCardMember";
 
 interface Props {
   data: RecordData;
@@ -56,7 +56,7 @@ function RecordCard({ data }: Props) {
           (members.length ? (
             <div className="members grid grid-cols-2 gap-2">
               {members.map((member) => (
-                <Member
+                <RecordCardMember
                   key={`${data.id}:${member.id}`}
                   clientUserId={clientUserId}
                   isMyRecord={isMyRecord}
@@ -149,58 +149,5 @@ function ExpandButton({
         <MdArrowDropDown className="h-12 w-12 hover:scale-125 transition" />
       )}
     </button>
-  );
-}
-
-function Member({
-  member,
-  isMyRecord,
-  clientUserId,
-  scoresLength,
-}: {
-  member: {
-    id: number;
-    name: string;
-    profileImage: string | null;
-    isRated: boolean;
-  };
-  isMyRecord: boolean;
-  clientUserId: number;
-  scoresLength: number;
-}) {
-  const commonButtonStyle =
-    "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
-  const buttonStyles = {
-    "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
-    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
-    "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
-    "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
-  };
-  return (
-    <div className="member flex gap-4 items-center">
-      <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
-      {isMyRecord &&
-        clientUserId === member.id &&
-        (scoresLength ? (
-          <button type="button" className={buttonStyles["outlined-blue"]}>
-            수정하기
-          </button>
-        ) : (
-          <button type="button" className={buttonStyles["filled-blue"]}>
-            점수등록
-          </button>
-        ))}
-      {isMyRecord &&
-        clientUserId !== member.id &&
-        (member.isRated ? (
-          <button type="button" className={buttonStyles["outlined-gray"]}>
-            완료
-          </button>
-        ) : (
-          <button type="button" className={buttonStyles["outlined-orange"]}>
-            별점주기
-          </button>
-        ))}
-    </div>
   );
 }

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -66,7 +66,7 @@ function RecordCard({ data }: Props) {
                   clientUserId={clientUserId}
                   isMyRecord={isMyRecord}
                   member={member}
-                  scores={scores}
+                  scoresLength={scores.length}
                 />
               ))}
             </div>
@@ -169,7 +169,7 @@ function Member({
   member,
   isMyRecord,
   clientUserId,
-  scores,
+  scoresLength,
 }: {
   member: {
     id: number;
@@ -179,11 +179,7 @@ function Member({
   };
   isMyRecord: boolean;
   clientUserId: number;
-  scores: {
-    id: number;
-    score: number;
-    scoreImage: string | null;
-  }[];
+  scoresLength: number;
 }) {
   const commonButtonStyle =
     "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
@@ -198,7 +194,7 @@ function Member({
       <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
       {isMyRecord &&
         clientUserId === member.id &&
-        (scores.length ? (
+        (scoresLength ? (
           <button type="button" className={buttonStyles["outlined-blue"]}>
             수정하기
           </button>

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Dispatch, SetStateAction, useState } from "react";
 import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
+import Button from "@/components/atoms/Button";
 import RecordCardMember from "../RecordCardMember";
 
 interface Props {
@@ -101,13 +102,12 @@ function ScoreWithImageButton({ scoreObj }: { scoreObj: RecordData["scores"][num
     <div className="score flex gap-2">
       <span>{`스코어 ${scoreObj.id} | ${scoreObj.score}`}</span>
       {scoreObj.scoreImage && (
-        <button
-          type="button"
-          className="inline-flex items-center gap-x-0.5 border border-thunderOrange text-thunderOrange text-sm rounded-full px-2 py-[3px] bg-white hover:brightness-95"
-        >
-          <MdCameraAlt className="inline" />
-          <span className="leading-none">이미지 보기</span>
-        </button>
+        <Button rounded="full" size="xs" styleType="outlined-orange" fontWeight="normal">
+          <div className="inline-flex items-center gap-x-0.5 ">
+            <MdCameraAlt className="inline" />
+            <span className="leading-none">이미지 보기</span>
+          </div>
+        </Button>
       )}
     </div>
   );

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useState } from "react";
 import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
+import MiniProfile from "../MiniProfile";
 
 interface Props {
   data: RecordData;
@@ -107,10 +108,7 @@ function RecordCard({ data }: Props) {
                 };
                 return (
                   <div key={`${data.id}:${member.id}`} className="member flex gap-4 items-center">
-                    <Link href={`/user_profile/${member.id}`} className="flex gap-1 items-center">
-                      <CircularProfileImage src={member.profileImage} />
-                      <span className="member-name text-xl">{member.name}</span>
-                    </Link>
+                    <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
                     {isMyRecord &&
                       myId === member.id &&
                       (scores.length ? (

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -75,7 +75,13 @@ function RecordCard({ data }: Props) {
 
 export default RecordCard;
 
-function RecordTimeWithLocation({ districtName, startTime }: { districtName: string; startTime: Date }) {
+function RecordTimeWithLocation({
+  districtName,
+  startTime,
+}: {
+  districtName: RecordData["districtName"];
+  startTime: RecordData["startTime"];
+}) {
   return (
     <div className="record-info-wrapper flex gap-4 text-neutral-400">
       <p className="district-name">
@@ -90,7 +96,7 @@ function RecordTimeWithLocation({ districtName, startTime }: { districtName: str
   );
 }
 
-function ScoreWithImageButton({ scoreObj }: { scoreObj: { id: number; score: number; scoreImage: string | null } }) {
+function ScoreWithImageButton({ scoreObj }: { scoreObj: RecordData["scores"][number] }) {
   return (
     <div className="score flex gap-2">
       <span>{`스코어 ${scoreObj.id} | ${scoreObj.score}`}</span>
@@ -107,16 +113,7 @@ function ScoreWithImageButton({ scoreObj }: { scoreObj: { id: number; score: num
   );
 }
 
-function MembersImagePreview({
-  members,
-}: {
-  members: {
-    id: number;
-    name: string;
-    profileImage: string | null;
-    isRated: boolean;
-  }[];
-}) {
+function MembersImagePreview({ members }: { members: RecordData["members"] }) {
   return members.length > 3 ? (
     <>
       {members.slice(0, 3).map((member) => (

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import Button, { ButtonProps } from "@/components/atoms/Button";
+import Button from "@/components/atoms/Button";
 import { RecordData } from "@/types/recordData";
 import MiniProfile from "../MiniProfile";
 
@@ -17,43 +17,27 @@ function RecordCardMember({ member, isMyRecord, clientUserId, scoresLength }: Pr
       {isMyRecord &&
         clientUserId === member.id &&
         (scoresLength ? (
-          <MyButton styleType="outlined-blue">수정하기</MyButton>
+          <Button size="xs" rounded="full" styleType="outlined-blue" fontWeight="normal">
+            수정하기
+          </Button>
         ) : (
-          <MyButton styleType="filled-blue">점수등록</MyButton>
+          <Button size="xs" rounded="full" styleType="filled-blue" fontWeight="normal">
+            점수등록
+          </Button>
         ))}
       {isMyRecord &&
         clientUserId !== member.id &&
         (member.isRated ? (
-          <MyButton styleType="outlined-gray">완료</MyButton>
+          <Button size="xs" rounded="full" styleType="outlined-gray" fontWeight="normal">
+            완료
+          </Button>
         ) : (
-          <MyButton styleType="outlined-orange">별점주기</MyButton>
+          <Button size="xs" rounded="full" styleType="outlined-orange" fontWeight="normal">
+            별점주기
+          </Button>
         ))}
     </div>
   );
 }
 
 export default RecordCardMember;
-
-interface MyButtonProp {
-  children: ButtonProps["children"];
-  styleType: ButtonProps["styleType"];
-  onClick?: ButtonProps["onClick"];
-}
-
-function MyButton({ children, styleType, onClick }: MyButtonProp) {
-  return (
-    <Button
-      size="sm"
-      rounded="full"
-      styleType={styleType}
-      fontSize="sm"
-      fontWeight="normal"
-      minWidth="70px"
-      padding="px-2_py-[3px]"
-      noLineHeight
-      onClick={onClick}
-    >
-      {children}
-    </Button>
-  );
-}

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,23 +1,16 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import Button, { ButtonProps } from "@/components/atoms/Button";
+import { RecordData } from "@/types/recordData";
 import MiniProfile from "../MiniProfile";
 
-function RecordCardMember({
-  member,
-  isMyRecord,
-  clientUserId,
-  scoresLength,
-}: {
-  member: {
-    id: number;
-    name: string;
-    profileImage: string | null;
-    isRated: boolean;
-  };
+interface Prop {
+  member: RecordData["members"][number];
   isMyRecord: boolean;
   clientUserId: number;
   scoresLength: number;
-}) {
+}
+
+function RecordCardMember({ member, isMyRecord, clientUserId, scoresLength }: Prop) {
   return (
     <div className="member flex gap-4 items-center">
       <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import Button, { ButtonProps } from "@/components/atoms/Button";
 import MiniProfile from "../MiniProfile";
 
 function RecordCardMember({
@@ -16,41 +18,49 @@ function RecordCardMember({
   clientUserId: number;
   scoresLength: number;
 }) {
-  const commonButtonStyle =
-    "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
-  const buttonStyles = {
-    "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
-    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
-    "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
-    "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
-  };
   return (
     <div className="member flex gap-4 items-center">
       <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
       {isMyRecord &&
         clientUserId === member.id &&
         (scoresLength ? (
-          <button type="button" className={buttonStyles["outlined-blue"]}>
-            수정하기
-          </button>
+          <MyButton styleType="outlined-blue">수정하기</MyButton>
         ) : (
-          <button type="button" className={buttonStyles["filled-blue"]}>
-            점수등록
-          </button>
+          <MyButton styleType="filled-blue">점수등록</MyButton>
         ))}
       {isMyRecord &&
         clientUserId !== member.id &&
         (member.isRated ? (
-          <button type="button" className={buttonStyles["outlined-gray"]}>
-            완료
-          </button>
+          <MyButton styleType="outlined-gray">완료</MyButton>
         ) : (
-          <button type="button" className={buttonStyles["outlined-orange"]}>
-            별점주기
-          </button>
+          <MyButton styleType="outlined-orange">별점주기</MyButton>
         ))}
     </div>
   );
 }
 
 export default RecordCardMember;
+
+interface MyButtonProp {
+  children: ButtonProps["children"];
+  styleType: ButtonProps["styleType"];
+  onClick?: ButtonProps["onClick"];
+}
+
+function MyButton({ children, styleType, onClick }: MyButtonProp) {
+  return (
+    <Button
+      size="sm"
+      rounded="full"
+      styleType={styleType}
+      fontSize="sm"
+      fontWeight="normal"
+      minWidth="70px"
+      padding="px-2_py-[3px]"
+      noLineHeight
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,0 +1,56 @@
+import MiniProfile from "../MiniProfile";
+
+function RecordCardMember({
+  member,
+  isMyRecord,
+  clientUserId,
+  scoresLength,
+}: {
+  member: {
+    id: number;
+    name: string;
+    profileImage: string | null;
+    isRated: boolean;
+  };
+  isMyRecord: boolean;
+  clientUserId: number;
+  scoresLength: number;
+}) {
+  const commonButtonStyle =
+    "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
+  const buttonStyles = {
+    "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
+    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
+    "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
+    "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
+  };
+  return (
+    <div className="member flex gap-4 items-center">
+      <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
+      {isMyRecord &&
+        clientUserId === member.id &&
+        (scoresLength ? (
+          <button type="button" className={buttonStyles["outlined-blue"]}>
+            수정하기
+          </button>
+        ) : (
+          <button type="button" className={buttonStyles["filled-blue"]}>
+            점수등록
+          </button>
+        ))}
+      {isMyRecord &&
+        clientUserId !== member.id &&
+        (member.isRated ? (
+          <button type="button" className={buttonStyles["outlined-gray"]}>
+            완료
+          </button>
+        ) : (
+          <button type="button" className={buttonStyles["outlined-orange"]}>
+            별점주기
+          </button>
+        ))}
+    </div>
+  );
+}
+
+export default RecordCardMember;

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -41,9 +41,10 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("all");
           }}
-          styleType={condition === "all" ? "thunder" : "outlined-gray"}
+          styleType={condition === "all" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           전체 보기
         </Button>
@@ -51,9 +52,10 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("created");
           }}
-          styleType={condition === "created" ? "thunder" : "outlined-gray"}
+          styleType={condition === "created" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           작성한 글
         </Button>
@@ -61,9 +63,10 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("participated");
           }}
-          styleType={condition === "participated" ? "thunder" : "outlined-gray"}
+          styleType={condition === "participated" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           참여한 글
         </Button>
@@ -73,9 +76,10 @@ function RecordFilter() {
           onClick={() => {
             handleStatus("all");
           }}
-          styleType={status === "all" ? "thunder" : "outlined-gray"}
+          styleType={status === "all" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           전체
         </Button>
@@ -86,6 +90,7 @@ function RecordFilter() {
           styleType={status === "closed" ? "thunder" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           모집 완료
         </Button>

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -41,7 +41,7 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("all");
           }}
-          styleType={condition === "all" ? "thunder-w-20" : "outlined-gray"}
+          styleType={condition === "all" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"
@@ -52,7 +52,7 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("created");
           }}
-          styleType={condition === "created" ? "thunder-w-20" : "outlined-gray"}
+          styleType={condition === "created" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"
@@ -63,7 +63,7 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("participated");
           }}
-          styleType={condition === "participated" ? "thunder-w-20" : "outlined-gray"}
+          styleType={condition === "participated" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"
@@ -76,7 +76,7 @@ function RecordFilter() {
           onClick={() => {
             handleStatus("all");
           }}
-          styleType={status === "all" ? "thunder-w-20" : "outlined-gray"}
+          styleType={status === "all" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -1,0 +1,5 @@
+function RecordFilter() {
+  return <div>RecordFilter</div>;
+}
+
+export default RecordFilter;

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -36,13 +36,13 @@ function RecordFilter() {
 
   return (
     <div className="post-filter flex flex-col gap-2">
-      <div className="post-filter-condition flex w-fit gap-2">
+      <div className="post-filter-condition flex w-fit gap-2 h-7">
         <Button
           onClick={() => {
             handleCondition("all");
           }}
           styleType={condition === "all" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
@@ -53,7 +53,7 @@ function RecordFilter() {
             handleCondition("created");
           }}
           styleType={condition === "created" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
@@ -64,20 +64,20 @@ function RecordFilter() {
             handleCondition("participated");
           }}
           styleType={condition === "participated" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
           참여한 글
         </Button>
       </div>
-      <div className="post-filter-status flex w-fit gap-2">
+      <div className="post-filter-status flex w-fit gap-2 h-7">
         <Button
           onClick={() => {
             handleStatus("all");
           }}
           styleType={status === "all" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
@@ -88,7 +88,7 @@ function RecordFilter() {
             handleStatus("closed");
           }}
           styleType={status === "closed" ? "thunder" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -1,5 +1,97 @@
+"use client";
+
+import Button from "@/components/atoms/Button";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
 function RecordFilter() {
-  return <div>RecordFilter</div>;
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [condition, setCondition] = useState(searchParams.get("condition") || "all");
+  const [status, setStatus] = useState(searchParams.get("status") || "all");
+
+  useEffect(() => {
+    setCondition(searchParams.get("condition") || "all");
+    setStatus(searchParams.get("status") || "all");
+  }, [searchParams]);
+
+  const handleCondition = useCallback(
+    (newCondition: "all" | "created" | "participated") => {
+      const searchParamObj = new URLSearchParams(searchParams);
+      searchParamObj.set("condition", newCondition);
+      const queryString = searchParamObj.toString();
+      router.push(`?${queryString}`);
+    },
+    [router, searchParams],
+  );
+  const handleStatus = useCallback(
+    (newStatus: "all" | "closed") => {
+      const searchParamObj = new URLSearchParams(searchParams);
+      searchParamObj.set("status", newStatus);
+      const queryString = searchParamObj.toString();
+      router.push(`?${queryString}`);
+    },
+    [router, searchParams],
+  );
+
+  return (
+    <div className="post-filter flex flex-col gap-2">
+      <div className="post-filter-condition flex w-fit gap-2">
+        <Button
+          onClick={() => {
+            handleCondition("all");
+          }}
+          styleType={condition === "all" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          전체 보기
+        </Button>
+        <Button
+          onClick={() => {
+            handleCondition("created");
+          }}
+          styleType={condition === "created" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          작성한 글
+        </Button>
+        <Button
+          onClick={() => {
+            handleCondition("participated");
+          }}
+          styleType={condition === "participated" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          참여한 글
+        </Button>
+      </div>
+      <div className="post-filter-status flex w-fit gap-2">
+        <Button
+          onClick={() => {
+            handleStatus("all");
+          }}
+          styleType={status === "all" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          전체
+        </Button>
+        <Button
+          onClick={() => {
+            handleStatus("closed");
+          }}
+          styleType={status === "closed" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          모집 완료
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export default RecordFilter;

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -1,0 +1,5 @@
+function RecordSearchBar() {
+  return <div>RecordSearchBar</div>;
+}
+
+export default RecordSearchBar;

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -1,5 +1,22 @@
+"use client";
+
+import Button from "@/components/atoms/Button";
+import Dropdown from "@/components/atoms/Dropdown";
+
 function RecordSearchBar() {
-  return <div>RecordSearchBar</div>;
+  return (
+    <div className="record-search-bar flex gap-4">
+      <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "전체 지역" }]} />
+      <div className="period-dropdown flex gap-2 items-center">
+        <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "1111년 11월" }]} />
+        <span className="leading-none">~</span>
+        <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "9999년 9월" }]} />
+      </div>
+      <Button styleType="thunder" size="sm" rounded="full">
+        조회
+      </Button>
+    </div>
+  );
 }
 
 export default RecordSearchBar;

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -12,7 +12,7 @@ function RecordSearchBar() {
         <span className="leading-none">~</span>
         <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "9999년 9월" }]} />
       </div>
-      <Button styleType="thunder" size="sm" rounded="full">
+      <Button styleType="thunder-w-20" fontWeight="normal" size="sm" rounded="full">
         조회
       </Button>
     </div>

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { MdArrowBack } from "react-icons/md";
 import OptionTitle from "@/components/atoms/OptionTitle";
 import Button from "@/components/atoms/Button";
 import DatePicker from "@/components/molecules/DatePicker";
-import { useRouter } from "next/navigation";
 import DropdownBox from "@/components/molecules/DropdownBox";
 import { postRegisterPosts } from "@/apis/posts";
 import { useMutation } from "@tanstack/react-query";
@@ -20,14 +18,7 @@ function CreatePostForm() {
 
   const errRef = useRef<HTMLParagraphElement>(null);
 
-  const router = useRouter();
-
   const { mutate } = useMutation({ mutationFn: postRegisterPosts });
-
-  const handleBack = () => {
-    router.refresh();
-    router.push("/");
-  };
 
   const handleSubmit = () => {
     const currentTime = new Date();
@@ -69,7 +60,6 @@ function CreatePostForm() {
 
   return (
     <div>
-      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
       <h2 className="my-4 font-bold text-2xl">모집글 작성</h2>
       <OptionTitle>제목</OptionTitle>
       <input

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { MdArrowBack, MdLocationOn, MdOutlineEdit, MdOutlineDelete, MdAlarm } from "react-icons/md";
-import { useRouter } from "next/navigation";
+import { MdLocationOn, MdOutlineEdit, MdOutlineDelete, MdAlarm } from "react-icons/md";
 import { useQuery } from "@tanstack/react-query";
 import { getPostById } from "@/apis/posts";
 import Badge from "@/components/atoms/Badge";
@@ -16,7 +15,6 @@ interface Props {
 }
 
 function PostTemplates({ id }: Props) {
-  const router = useRouter();
   const parameter = parseInt(id, 10);
 
   const { data } = useQuery([`/api/posts${id}`, id], () => getPostById(parameter), {
@@ -27,13 +25,8 @@ function PostTemplates({ id }: Props) {
 
   const post = data?.data?.response.post || {};
 
-  const handleBack = () => {
-    router.refresh();
-    router.push("/");
-  };
   return (
     <div>
-      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
       <div className="flex justify-between mt-6">
         <Badge isClose={post.isClose} />
         <div className="flex items-center">

--- a/src/components/templates/ProfileModalTemplate/index.tsx
+++ b/src/components/templates/ProfileModalTemplate/index.tsx
@@ -9,7 +9,7 @@ import { MdLocationPin, MdMail, MdLeaderboard } from "react-icons/md";
 function ProfileModalTemplate() {
   const buttonStyle = "min-w-[150px] p-2 mx-auto flex gap-2 justify-center items-center  bg-neutral-200 rounded-full";
   const pageParam = useParams();
-  const { data, isLoading, isError } = useQuery({
+  const { data } = useQuery({
     queryFn: () => getProfileById(parseInt(pageParam.user_id as string, 10)),
   });
 

--- a/src/components/templates/ScoreboardTemplate/index.tsx
+++ b/src/components/templates/ScoreboardTemplate/index.tsx
@@ -1,5 +1,66 @@
+import RecordSummary from "@/components/atoms/RecordSummary";
+import RecordCard from "@/components/molecules/RecordCard";
+import RecordFilter from "@/components/molecules/RecordFilter";
+import RecordSearchBar from "@/components/molecules/RecordSearchBar";
+
 function ScoreboardTemplate() {
-  return <div>스코어보드템플릿</div>;
+  const dummy = {
+    id: 2,
+    title: "오늘 7시에 부산대 락볼링장에서 게임하실분~~",
+    dueTime: "2023-09-07T21:00:00",
+    districtName: "부산광역시 금정구 장전2동",
+    startTime: "2023-09-09T19:00:00",
+    currentNumber: 1,
+    isClose: true,
+    scores: [
+      {
+        id: 1,
+        score: 180,
+        scoreImage: "/score-images/1.jpg",
+      },
+      {
+        id: 2,
+        score: 210,
+        scoreImage: null,
+      },
+    ],
+    members: [
+      {
+        id: 2,
+        name: "최볼링",
+        profileImage: null,
+        isRated: true,
+      },
+      {
+        id: 3,
+        name: "이볼링",
+        profileImage: null,
+        isRated: false,
+      },
+      {
+        id: 4,
+        name: "최볼링",
+        profileImage: null,
+        isRated: true,
+      },
+      {
+        id: 1,
+        name: "김볼링",
+        profileImage: null,
+        isRated: false,
+      },
+    ],
+  };
+  return (
+    <div className="scoreboard flex flex-col gap-5">
+      <h1 className="title text-2xl">{"김볼링"}님의 기록</h1>
+      <RecordSummary game={20} average={160} maximum={180} minimum={110} />
+      <h2 className="title text-xl">참여 기록</h2>
+      <RecordFilter />
+      <RecordSearchBar />
+      <RecordCard data={dummy} />
+    </div>
+  );
 }
 
 export default ScoreboardTemplate;

--- a/src/components/templates/ScoreboardTemplate/index.tsx
+++ b/src/components/templates/ScoreboardTemplate/index.tsx
@@ -1,0 +1,5 @@
+function ScoreboardTemplate() {
+  return <div>스코어보드템플릿</div>;
+}
+
+export default ScoreboardTemplate;

--- a/src/components/templates/ScoreboardTemplate/index.tsx
+++ b/src/components/templates/ScoreboardTemplate/index.tsx
@@ -54,7 +54,7 @@ function ScoreboardTemplate() {
   return (
     <div className="scoreboard flex flex-col gap-5">
       <h1 className="title text-2xl">{"김볼링"}님의 기록</h1>
-      <RecordSummary game={20} average={160} maximum={180} minimum={110} />
+      <RecordSummary data={{ game: 20, average: 160, maximum: 180, minimum: 110 }} />
       <h2 className="title text-xl">참여 기록</h2>
       <RecordFilter />
       <RecordSearchBar />

--- a/src/types/recordData.ts
+++ b/src/types/recordData.ts
@@ -1,0 +1,20 @@
+export interface RecordData {
+  id: number;
+  title: string;
+  dueTime: Date;
+  districtName: string;
+  startTime: Date;
+  currentNumber: number;
+  isClose: boolean;
+  scores: {
+    id: number;
+    score: number;
+    scoreImage: string | null;
+  }[];
+  members: {
+    id: number;
+    name: string;
+    profileImage: string | null;
+    isRated: boolean;
+  }[];
+}


### PR DESCRIPTION
## 개요
### 참여기록 페이지 UI 구현
- BackArrowContainer 제작
- RecordSummary UI 제작 - 모든 경기에 대한 요약을 제공
- RecordFilter 제작 - 검색된 참여기록을 분류
    - UI 및 기능 개발 완료
- RecordSearchBar UI 제작 - 참여기록을 검색
- RecordCard UI 제작 - 하나의 참여 기록(모집글)을 표현
  - RecordCard 내의 요소들 컴포넌트화 - not exported
- ScoreboardTemplate 및 /app/scoreboard/[user_id]/page.tsx 생성 - 스코어보드 페이지 
### 추가 작업 내용
- BackArrowContainer 서버컴포넌트화
  - BackArrowButton을 분리하여 컴포넌트화
- BackArrowContainer 적용 - 글쓰기, 모집글 확인 페이지
- RecordCardMember - RecordCard의 Member 컴포넌트를 따로 분리
- ProfileModalTemplate - ESLint 에러가 나는 사용하지 않는 삭제
- RecordCard 내부 컴포넌트 prop 타입 리팩토링
- Button 컴포넌트 prop 추가 및 내부 스타일 적용 로직 리팩토링

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 특이사항
- 기능개발이 되어있지 않은 부분은 더미데이터가 하드코딩 되어 있습니다. - ScoreboardTemplate 등
- RecordCard UI 개발 후 코드의 길이가 너무 길어 리팩토링을 조금 진행했습니다. 
  - RecordCard의 일부인 요소들을 컴포넌트화 하려 했으나, 재사용성이 없어 보여, 컴포넌트로 분리하지 않고, RecordCard 파일 내에 다른 함수로 구분해 두었습니다.
  - 아직도 RecordCard의 코드가 마음에 들지는 않지만 기능 개발이 우선일 것 같아 추후에 리팩토링 진행하려 합니다.
  - 더 좋은 방법이 있다면 알려주세요