### PR TITLE
[Feat] 댓글 수정 / 삭제 / 답글 달기 구현

### DIFF
--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -36,3 +36,18 @@ export async function putComments({
   });
   return response;
 }
+
+export async function postReply({
+  postId,
+  commentId,
+  content,
+}: {
+  postId: number;
+  commentId: number;
+  content: string;
+}) {
+  const response = await client.post(`/api/posts/${postId}/comments/${commentId}/reply`, {
+    content,
+  });
+  return response;
+}

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -16,3 +16,8 @@ export async function postComments({ id, content }: { id: number; content: strin
   });
   return response;
 }
+
+export async function deleteComments({ postId, commentId }: { postId: number; commentId: number }) {
+  const response = await client.delete(`/api/posts/${postId}/comments/${commentId}`);
+  return response;
+}

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -21,3 +21,18 @@ export async function deleteComments({ postId, commentId }: { postId: number; co
   const response = await client.delete(`/api/posts/${postId}/comments/${commentId}`);
   return response;
 }
+
+export async function putComments({
+  postId,
+  commentId,
+  content,
+}: {
+  postId: number;
+  commentId: number;
+  content: string;
+}) {
+  const response = await client.put(`/api/posts/${postId}/comments/${commentId}`, {
+    content,
+  });
+  return response;
+}

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -1,10 +1,8 @@
-import { MdOutlineSubdirectoryArrowRight, MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
+import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
 import React from "react";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
-import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
-import { deleteComments } from "@/apis/comment";
-import { getCookie } from "@/utils/Cookie";
+import CommentBlock from "../CommentBlock";
 
 interface Props {
   childComment: CommentData;
@@ -12,50 +10,13 @@ interface Props {
 }
 
 function ChildComment({ childComment, id }: Props) {
-  const userId = parseInt(getCookie("userId"), 10);
-
-  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
-
-  const handleDeleteComment = () => {
-    const payload = {
-      postId: id,
-      commentId: childComment.id,
-    };
-    mutate(payload, {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["/comments", id]);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    });
-  };
-
   return (
     <>
       <div className="flex items-center gap-3">
         <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <div className="flex items-center justify-between">
-            <span className="text-[#2a5885]">{childComment.userName}</span>
-            <div className="flex items-center gap-2 text-neutral-400 text-sm">
-              {childComment.userId === userId && (
-                <>
-                  <button type="button" className="flex items-center cursor-pointer">
-                    <MdOutlineEdit />
-                    수정
-                  </button>
-                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
-                    <MdOutlineDelete />
-                    삭제
-                  </button>
-                </>
-              )}
-              <span>답글 달기</span>
-            </div>
-          </div>
-          <pre className="whitespace-pre-wrap break-all">{childComment.content}</pre>
+          <CommentBlock comment={childComment} id={id} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -15,7 +15,7 @@ function ChildComment({ childComment }: Props) {
         <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={childComment} />
+          <CommentBlock comment={childComment} isChild={false} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -6,17 +6,16 @@ import CommentBlock from "../CommentBlock";
 
 interface Props {
   childComment: CommentData;
-  id: number;
 }
 
-function ChildComment({ childComment, id }: Props) {
+function ChildComment({ childComment }: Props) {
   return (
     <>
       <div className="flex items-center gap-3">
         <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={childComment} id={id} />
+          <CommentBlock comment={childComment} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -42,10 +42,10 @@ function ChildComment({ childComment, id }: Props) {
             <div className="flex items-center gap-2 text-neutral-400 text-sm">
               {childComment.userId === userId && (
                 <>
-                  <span className="flex items-center cursor-pointer">
+                  <button type="button" className="flex items-center cursor-pointer">
                     <MdOutlineEdit />
                     수정
-                  </span>
+                  </button>
                   <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
                     <MdOutlineDelete />
                     삭제

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -1,13 +1,36 @@
-import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
+import { MdOutlineSubdirectoryArrowRight, MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import React from "react";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { deleteComments } from "@/apis/comment";
+import { getCookie } from "@/utils/Cookie";
 
 interface Props {
   childComment: CommentData;
+  id: number;
 }
 
-function ChildComment({ childComment }: Props) {
+function ChildComment({ childComment, id }: Props) {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
+
+  const handleDeleteComment = () => {
+    const payload = {
+      postId: id,
+      commentId: childComment.id,
+    };
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
   return (
     <>
       <div className="flex items-center gap-3">
@@ -16,8 +39,20 @@ function ChildComment({ childComment }: Props) {
         <div className="flex-1">
           <div className="flex items-center justify-between">
             <span className="text-[#2a5885]">{childComment.userName}</span>
-            <div className="text-neutral-400">
-              <span className="text-sm">답글 달기</span>
+            <div className="flex items-center gap-2 text-neutral-400 text-sm">
+              {childComment.userId === userId && (
+                <>
+                  <span className="flex items-center cursor-pointer">
+                    <MdOutlineEdit />
+                    수정
+                  </span>
+                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
+                    <MdOutlineDelete />
+                    삭제
+                  </button>
+                </>
+              )}
+              <span>답글 달기</span>
             </div>
           </div>
           <pre className="whitespace-pre-wrap break-all">{childComment.content}</pre>

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -64,7 +64,9 @@ function Comment({ comment, id }: Props) {
       </div>
       <hr className="mt-2" />
       {comment.childComments &&
-        comment.childComments.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
+        comment.childComments.map((childComment) => (
+          <ChildComment childComment={childComment} key={childComment.id} id={id} />
+        ))}
     </>
   );
 }

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -63,7 +63,7 @@ function Comment({ comment }: Props) {
         <>
           <div className="flex items-center gap-1">
             <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
-            <p>대댓글 등록</p>
+            <p>답글 달기</p>
           </div>
           <div className="flex items-center gap-3 mt-2">
             <CommentSubmit

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -1,13 +1,8 @@
-import React, { useRef, useState } from "react";
-import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
+import React from "react";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
-import { getCookie } from "@/utils/Cookie";
-import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
-import { deleteComments, putComments } from "@/apis/comment";
-import { useMutation } from "@tanstack/react-query";
 import ChildComment from "../ChildComment";
-import CommentSubmit from "../CommentSubmit";
+import CommentBlock from "../CommentBlock";
 
 export interface CommentWithChild extends CommentData {
   childComments: CommentData[];
@@ -19,86 +14,12 @@ interface Props {
 }
 
 function Comment({ comment, id }: Props) {
-  const userId = parseInt(getCookie("userId"), 10);
-
-  const [update, setUpdate] = useState(false);
-  const [commentContent, setCommentContent] = useState(comment.content);
-
-  const commentRef = useRef<HTMLTextAreaElement>(null);
-
-  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
-  const { mutate: putMutate } = useMutation(putComments);
-
-  const payload = {
-    postId: id,
-    commentId: comment.id,
-  };
-
-  const handleDeleteComment = () => {
-    mutate(payload, {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["/comments", id]);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    });
-  };
-  const handleUpdateForm = () => {
-    setUpdate((prev) => !prev);
-    setCommentContent(comment.content);
-  };
-  const handleUpdate = () => {
-    const putPayload = {
-      ...payload,
-      content: commentContent,
-    };
-    putMutate(putPayload, {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["/comments", id]);
-        setUpdate(false);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    });
-  };
-
   return (
     <>
       <div className="flex items-center gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <div className="flex items-center justify-between">
-            <span className="text-[#2a5885]">{comment.userName}</span>
-            <div className="flex items-center gap-2 text-neutral-400 text-sm">
-              {comment.userId === userId && (
-                <>
-                  <button type="button" onClick={handleUpdateForm} className="flex items-center cursor-pointer">
-                    <MdOutlineEdit />
-                    수정
-                  </button>
-                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
-                    <MdOutlineDelete />
-                    삭제
-                  </button>
-                </>
-              )}
-              <span>답글 달기</span>
-            </div>
-          </div>
-          {update ? (
-            <div className="flex items-center gap-3 mt-2">
-              <CommentSubmit
-                commentRef={commentRef}
-                onClick={handleUpdate}
-                value={commentContent}
-                setValue={setCommentContent}
-              />
-            </div>
-          ) : (
-            <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>
-          )}
+          <CommentBlock comment={comment} id={id} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -10,23 +10,20 @@ export interface CommentWithChild extends CommentData {
 
 interface Props {
   comment: CommentWithChild;
-  id: number;
 }
 
-function Comment({ comment, id }: Props) {
+function Comment({ comment }: Props) {
   return (
     <>
       <div className="flex items-center gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={comment} id={id} />
+          <CommentBlock comment={comment} />
         </div>
       </div>
       <hr className="mt-2" />
       {comment.childComments &&
-        comment.childComments.map((childComment) => (
-          <ChildComment childComment={childComment} key={childComment.id} id={id} />
-        ))}
+        comment.childComments.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
     </>
   );
 }

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -1,8 +1,13 @@
-import React from "react";
+import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
+import React, { useRef, useState } from "react";
+import { useParams } from "next/navigation";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
-import ChildComment from "../ChildComment";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { postReply } from "@/apis/comment";
 import CommentBlock from "../CommentBlock";
+import ChildComment from "../ChildComment";
+import CommentSubmit from "../CommentSubmit";
 
 export interface CommentWithChild extends CommentData {
   childComments: CommentData[];
@@ -13,15 +18,64 @@ interface Props {
 }
 
 function Comment({ comment }: Props) {
+  const params = useParams();
+  const id = parseInt(params.id as string, 10);
+
+  const [reply, setReply] = useState(false);
+  const [commentContent, setCommentContent] = useState("");
+
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(postReply);
+
+  const handleReplyForm = () => {
+    setReply((prev) => !prev);
+    setCommentContent("");
+  };
+
+  const handleReply = () => {
+    const payload = {
+      postId: id,
+      commentId: comment.id,
+      content: commentContent,
+    };
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+        setReply(false);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
   return (
     <>
       <div className="flex items-center gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={comment} />
+          <CommentBlock comment={comment} isChild handleReplyForm={handleReplyForm} />
         </div>
       </div>
       <hr className="mt-2" />
+      {reply && (
+        <>
+          <div className="flex items-center gap-1">
+            <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
+            <p>대댓글 등록</p>
+          </div>
+          <div className="flex items-center gap-3 mt-2">
+            <CommentSubmit
+              commentRef={commentRef}
+              onClick={handleReply}
+              value={commentContent}
+              setValue={setCommentContent}
+            />
+          </div>
+          <hr className="mt-2" />
+        </>
+      )}
       {comment.childComments &&
         comment.childComments.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
     </>

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -1,6 +1,10 @@
 import React from "react";
+import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import { getCookie } from "@/utils/Cookie";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { deleteComments } from "@/apis/comment";
 import ChildComment from "../ChildComment";
 
 export interface CommentWithChild extends CommentData {
@@ -9,9 +13,29 @@ export interface CommentWithChild extends CommentData {
 
 interface Props {
   comment: CommentWithChild;
+  id: number;
 }
 
-function Comment({ comment }: Props) {
+function Comment({ comment, id }: Props) {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
+
+  const handleDeleteComment = () => {
+    const payload = {
+      postId: id,
+      commentId: comment.id,
+    };
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
   return (
     <>
       <div className="flex items-center gap-3">
@@ -19,8 +43,20 @@ function Comment({ comment }: Props) {
         <div className="flex-1">
           <div className="flex items-center justify-between">
             <span className="text-[#2a5885]">{comment.userName}</span>
-            <div className="text-neutral-400">
-              <span className="text-sm">답글 달기</span>
+            <div className="flex items-center gap-2 text-neutral-400 text-sm">
+              {comment.userId === userId && (
+                <>
+                  <span className="flex items-center cursor-pointer">
+                    <MdOutlineEdit />
+                    수정
+                  </span>
+                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
+                    <MdOutlineDelete />
+                    삭제
+                  </button>
+                </>
+              )}
+              <span>답글 달기</span>
             </div>
           </div>
           <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -10,9 +10,11 @@ import CommentSubmit from "../CommentSubmit";
 
 interface Props {
   comment: CommentData;
+  isChild: boolean;
+  handleReplyForm?: any;
 }
 
-function CommentBlock({ comment }: Props) {
+function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
   const userId = parseInt(getCookie("userId"), 10);
   const params = useParams();
   const id = parseInt(params.id as string, 10);
@@ -79,7 +81,11 @@ function CommentBlock({ comment }: Props) {
               </button>
             </>
           )}
-          <span>답글 달기</span>
+          {isChild && (
+            <button type="button" onClick={handleReplyForm}>
+              답글 달기
+            </button>
+          )}
         </div>
       </div>
       {update ? (

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -1,6 +1,6 @@
 import { CommentData } from "@/types/commentData";
 import { getCookie } from "@/utils/Cookie";
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { deleteComments, putComments } from "@/apis/comment";
@@ -11,7 +11,7 @@ import CommentSubmit from "../CommentSubmit";
 interface Props {
   comment: CommentData;
   isChild: boolean;
-  handleReplyForm?: any;
+  handleReplyForm?: () => void;
 }
 
 function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
@@ -21,8 +21,6 @@ function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
 
   const [update, setUpdate] = useState(false);
   const [commentContent, setCommentContent] = useState(comment.content);
-
-  const commentRef = useRef<HTMLTextAreaElement>(null);
 
   const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
   const { mutate: putMutate } = useMutation(putComments);
@@ -90,12 +88,7 @@ function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
       </div>
       {update ? (
         <div className="flex items-center gap-3 mt-2">
-          <CommentSubmit
-            commentRef={commentRef}
-            onClick={handleUpdate}
-            value={commentContent}
-            setValue={setCommentContent}
-          />
+          <CommentSubmit onClick={handleUpdate} value={commentContent} setValue={setCommentContent} />
         </div>
       ) : (
         <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -1,0 +1,99 @@
+import { CommentData } from "@/types/commentData";
+import { getCookie } from "@/utils/Cookie";
+import React, { useRef, useState } from "react";
+import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { deleteComments, putComments } from "@/apis/comment";
+import { useMutation } from "@tanstack/react-query";
+import CommentSubmit from "../CommentSubmit";
+
+interface Props {
+  comment: CommentData;
+  id: number;
+}
+
+function CommentBlock({ comment, id }: Props) {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const [update, setUpdate] = useState(false);
+  const [commentContent, setCommentContent] = useState(comment.content);
+
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
+  const { mutate: putMutate } = useMutation(putComments);
+
+  const payload = {
+    postId: id,
+    commentId: comment.id,
+  };
+
+  const handleUpdateForm = () => {
+    setUpdate((prev) => !prev);
+    setCommentContent(comment.content);
+  };
+
+  const handleDeleteComment = () => {
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
+  const handleUpdate = () => {
+    const putPayload = {
+      ...payload,
+      content: commentContent,
+    };
+    putMutate(putPayload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+        setUpdate(false);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <span className="text-[#2a5885]">{comment.userName}</span>
+        <div className="flex items-center gap-2 text-neutral-400 text-sm">
+          {comment.userId === userId && (
+            <>
+              <button type="button" onClick={handleUpdateForm} className="flex items-center cursor-pointer">
+                <MdOutlineEdit />
+                수정
+              </button>
+              <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
+                <MdOutlineDelete />
+                삭제
+              </button>
+            </>
+          )}
+          <span>답글 달기</span>
+        </div>
+      </div>
+      {update ? (
+        <div className="flex items-center gap-3 mt-2">
+          <CommentSubmit
+            commentRef={commentRef}
+            onClick={handleUpdate}
+            value={commentContent}
+            setValue={setCommentContent}
+          />
+        </div>
+      ) : (
+        <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>
+      )}
+    </>
+  );
+}
+
+export default CommentBlock;

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -5,15 +5,17 @@ import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { deleteComments, putComments } from "@/apis/comment";
 import { useMutation } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
 import CommentSubmit from "../CommentSubmit";
 
 interface Props {
   comment: CommentData;
-  id: number;
 }
 
-function CommentBlock({ comment, id }: Props) {
+function CommentBlock({ comment }: Props) {
   const userId = parseInt(getCookie("userId"), 10);
+  const params = useParams();
+  const id = parseInt(params.id as string, 10);
 
   const [update, setUpdate] = useState(false);
   const [commentContent, setCommentContent] = useState(comment.content);

--- a/src/components/molecules/CommentSubmit/index.tsx
+++ b/src/components/molecules/CommentSubmit/index.tsx
@@ -3,30 +3,37 @@ import { MdSend } from "react-icons/md";
 
 interface Props {
   commentRef: React.RefObject<HTMLTextAreaElement>;
+  value?: string;
+  setValue?: React.Dispatch<React.SetStateAction<string>>;
   onClick: () => void;
 }
 
-function CommentSubmit({ commentRef, onClick }: Props) {
-  const currentRef = commentRef.current;
+function CommentSubmit({ commentRef, value, setValue, onClick }: Props) {
+  const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const textarea = e.target;
 
-  const handleResize = () => {
-    if (currentRef!.clientHeight >= 86) {
-      currentRef!.style.overflowY = "auto";
-    } else {
-      currentRef!.style.overflowY = "hidden";
+    if (setValue) {
+      setValue(textarea.value);
     }
-    currentRef!.style.height = "auto";
-    currentRef!.style.height = `${currentRef!.scrollHeight}px`;
+
+    if (textarea.clientHeight >= 86) {
+      textarea.style.overflowY = "auto";
+    } else {
+      textarea.style.overflowY = "hidden";
+    }
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
   };
 
   return (
     <>
       <textarea
-        className="resize-none w-5/6 h-[40px] max-h-[88px] py-2 px-3 rounded-lg border border-gray-400 overflow-y-hidden"
+        className="resize-none flex-1 h-[40px] max-h-[88px] py-2 px-3 rounded-lg border border-gray-400 overflow-y-hidden"
         placeholder="내용을 입력해 주세요."
         rows={1}
         ref={commentRef}
-        onInput={handleResize}
+        value={value}
+        onChange={handleOnChange}
       />
       <MdSend size="36" className="text-neutral-400 cursor-pointer" onClick={onClick} />
     </>

--- a/src/components/molecules/CommentSubmit/index.tsx
+++ b/src/components/molecules/CommentSubmit/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { MdSend } from "react-icons/md";
 
 interface Props {
-  commentRef: React.RefObject<HTMLTextAreaElement>;
+  commentRef?: React.RefObject<HTMLTextAreaElement>;
   value?: string;
   setValue?: React.Dispatch<React.SetStateAction<string>>;
   onClick: () => void;

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -81,7 +81,7 @@ function CommentForm({ id }: Props) {
         {data?.pages?.map(
           (page) =>
             page?.data?.response?.comments.map((comment: CommentWithChild) => (
-              <Comment comment={comment} key={comment.id} id={id} />
+              <Comment comment={comment} key={comment.id} />
             )),
         )}
       </div>

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -2,10 +2,10 @@
 
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { getComments } from "@/apis/comment";
+import { getComments, postComments } from "@/apis/comment";
 import Comment, { CommentWithChild } from "@/components/molecules/Comment";
 import CommentSubmit from "@/components/molecules/CommentSubmit";
-import useCommentsMutation from "@/hooks/useCommentsMutation";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
 
 interface Props {
@@ -25,7 +25,7 @@ function CommentForm({ id }: Props) {
     },
   );
 
-  const { mutate, queryClient } = useCommentsMutation();
+  const { mutate, queryClient } = useMutateWithQueryClient(postComments);
 
   const commentRef = useRef<HTMLTextAreaElement>(null);
   const target = useRef<HTMLDivElement>(null);
@@ -81,7 +81,7 @@ function CommentForm({ id }: Props) {
         {data?.pages?.map(
           (page) =>
             page?.data?.response?.comments.map((comment: CommentWithChild) => (
-              <Comment comment={comment} key={comment.id} />
+              <Comment comment={comment} key={comment.id} id={id} />
             )),
         )}
       </div>

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -73,7 +73,7 @@ function CommentForm({ id }: Props) {
   return (
     <div>
       <h2 className="mt-4 text-xl">댓글</h2>
-      <div className="mt-6 flex items-center justify-between">
+      <div className="mt-6 flex items-center justify-between gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <CommentSubmit commentRef={commentRef} onClick={handleSubmit} />
       </div>

--- a/src/hooks/useCommentsMutation.ts
+++ b/src/hooks/useCommentsMutation.ts
@@ -1,9 +1,0 @@
-import { postComments } from "@/apis/comment";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-
-export default function useCommentsMutation() {
-  const queryClient = useQueryClient();
-  const { mutate } = useMutation({ mutationFn: postComments });
-
-  return { mutate, queryClient };
-}

--- a/src/hooks/useMutateWithQueryClient.ts
+++ b/src/hooks/useMutateWithQueryClient.ts
@@ -1,0 +1,8 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export default function useMutateWithQueryClient(fetcher: (arg: any) => Promise<any>) {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({ mutationFn: fetcher });
+
+  return { mutate, queryClient };
+}


### PR DESCRIPTION
## 개요

- ComentBlock 컴포넌트 분리
댓글과 대댓글의 수정 / 삭제 로직이 같아서 안의 내용과 UI를 컴포넌트로 분리 했음
- 댓글 삭제 구현
삭제 버튼을 눌렀을 시 해당 댓글을 삭제 mutate함수와 invalidateQueries 사용
- 댓글 수정 구현
수정 버튼을 눌렀을 때 댓글 수정 폼으로 변환 update state 사용
기존 댓글을 textarea에 담음
수정 폼에서 버튼을 누르면 댓글을 수정 mutate함수와 invalidateQueries 사용
- 답글 달기 구현
댓글에서만 답글 달기가 보임
답글 달기 버튼을 눌렀을 때 답글 폼으로 변환 reply state 사용
답글 폼에서 버튼을 누르면 답글이 달림 mutate함수와 invalidateQueries 사용
- postId 값이 prop drilling이 일어나던 것 리팩토링
useParams()로 받아 사용

Resolves: #42 

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 특이사항
댓글이 여러 줄일 때 수정을 하면 textarea의 크기가 따라가지는 않음
추후에 시간이 남으면 수정할 수 있을 듯