### PR TITLE
[Feat] 신청 / 취소 / 신청자 확인 기능 추가

### DIFF
--- a/src/apis/applicant.ts
+++ b/src/apis/applicant.ts
@@ -27,3 +27,9 @@ export async function postApply(postId: number) {
   const res = await client.post(`/api/posts/${postId}/applicants`);
   return res;
 }
+
+export async function getCheckStatus(postId: number) {
+  if (!postId) throw new Error("postApply: postId 또는 accessToken이 유효하지 않습니다.");
+  const res = await client.get(`api/posts/${postId}/applicants/check-status`);
+  return res;
+}

--- a/src/apis/applicant.ts
+++ b/src/apis/applicant.ts
@@ -15,7 +15,7 @@ export async function putAcceptApplicant(postId: number, applicantId: number) {
   return res;
 }
 
-export async function deleteRejectApplicant(postId: number, applicantId: number) {
+export async function deleteRejectApplicant({ postId, applicantId }: { postId: number; applicantId: number }) {
   if (!postId) throw new Error("deleteRejectApplicant: postId 또는 accessToken이 유효하지 않습니다.");
   if (!applicantId) throw new Error("deleteRejectApplicant: applicantId가 유효하지 않습니다.");
   const res = await client.delete(`/api/posts/${postId}/applicants/${applicantId}`);

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,5 +1,5 @@
 export interface ButtonProps {
-  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
+  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue" | "filled-red";
   rounded: "full" | "md";
   size: "lg" | "sm" | "xs";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -16,6 +16,7 @@ function Button({ styleType, rounded, size, onClick, children, fontWeight = "bol
     "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
     "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
     "filled-blue": `border text-white bg-blue-500`,
+    "filled-red": "bg-[#FF2E2E] text-white",
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",

--- a/src/components/molecules/ApplicantBlock/index.tsx
+++ b/src/components/molecules/ApplicantBlock/index.tsx
@@ -25,7 +25,7 @@ function ApplicantBlock({ postId, applicantData }: Prop): JSX.Element {
 
   const handleReject = useCallback(async () => {
     try {
-      await deleteRejectApplicant(postId, applicantId);
+      await deleteRejectApplicant({ postId, applicantId });
       setApprovalStatus("rejected");
     } catch {
       alert("거절 요청이 실패했습니다.");

--- a/src/components/molecules/ApplyButton/index.tsx
+++ b/src/components/molecules/ApplyButton/index.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { deleteRejectApplicant, getCheckStatus, postApply } from "@/apis/applicant";
+import Button from "@/components/atoms/Button";
+import { getCookie } from "@/utils/Cookie";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+
+interface Props {
+  postId: number;
+  authorId: number;
+}
+
+function ApplyButton({ postId, authorId }: Props): JSX.Element {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const router = useRouter();
+
+  const { data } = useQuery([`/api/posts${postId}/applicants/check-status`, postId], () => getCheckStatus(postId));
+
+  const { mutate: applyMutate } = useMutation({ mutationFn: postApply });
+  const { mutate: deleteMutate } = useMutation({ mutationFn: deleteRejectApplicant });
+
+  const [isApplied, setIsApplied] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsApplied(data?.data?.response.isApplied);
+  }, [data]);
+
+  const handleApply = () => {
+    applyMutate(postId, {
+      onSuccess: () => {
+        setIsApplied(true);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
+  const handleDeleteApply = () => {
+    deleteMutate(
+      { postId, applicantId: userId },
+      {
+        onSuccess: () => {
+          setIsApplied(false);
+        },
+        onError: (error) => {
+          console.log(error);
+        },
+      },
+    );
+  };
+
+  if (authorId === userId) {
+    return (
+      <Button
+        styleType="thunder"
+        rounded="md"
+        size="sm"
+        onClick={() => {
+          router.push(`/applicant_confirm/${postId}`, { scroll: false });
+        }}
+      >
+        신청자 확인
+      </Button>
+    );
+  }
+  if (isApplied) {
+    return (
+      <Button styleType="filled-red" rounded="md" size="sm" onClick={handleDeleteApply}>
+        신청취소
+      </Button>
+    );
+  }
+  return (
+    <Button styleType="thunder" rounded="md" size="sm" onClick={handleApply}>
+      신청하기
+    </Button>
+  );
+}
+
+export default ApplyButton;

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -6,9 +6,9 @@ import { getPostById } from "@/apis/posts";
 import Badge from "@/components/atoms/Badge";
 import Participant from "@/components/atoms/Participant";
 import { formatDateToString, formatDateToStringByDot } from "@/utils/formatDateToString";
-import Button from "@/components/atoms/Button";
 import CommentForm from "@/components/organisms/CommentForm";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import ApplyButton from "@/components/molecules/ApplyButton";
 
 interface Props {
   id: string;
@@ -72,9 +72,7 @@ function PostTemplates({ id }: Props): JSX.Element {
       </p>
       <pre className="whitespace-pre-wrap mt-4 break-all">{post.content}</pre>
       <div className="mt-4 flex flex-row-reverse">
-        <Button styleType="thunder" rounded="md" size="sm">
-          신청하기
-        </Button>
+        <ApplyButton postId={parameter} authorId={post.userId} />
       </div>
       <hr className="mt-6" />
       <CommentForm id={parameter} />


### PR DESCRIPTION
## 개요

게시글에 신청 / 취소 / 신청자 확인 기능을 추가 했습니다.

게시글 페이지에 들어갔을 때, 자신이 쓴 게시글이면 신청자 확인 버튼이 보이게되고,
다른 사람의 게시글이면 신청 / 취소 버튼이 보이게 됩니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 특이사항
백엔드에서 userId가 아닌 신청자의 applicantId를 따로 관리하고 있어서 신청마다 id를 게속 call 해줘야 합니다.
그래서 invalidateQueries를 사용하여 신청시에 id값을 새로 받아옵니다.
