### PR TITLE
6주차 개발 내용 정리

### DIFF
--- a/src/apis/applicant.ts
+++ b/src/apis/applicant.ts
@@ -27,3 +27,9 @@ export async function postApply(postId: number) {
   const res = await client.post(`/api/posts/${postId}/applicants`);
   return res;
 }
+
+export async function getCheckStatus(postId: number) {
+  if (!postId) throw new Error("postApply: postId 또는 accessToken이 유효하지 않습니다.");
+  const res = await client.get(`api/posts/${postId}/applicants/check-status`);
+  return res;
+}

--- a/src/apis/applicant.ts
+++ b/src/apis/applicant.ts
@@ -15,7 +15,7 @@ export async function putAcceptApplicant(postId: number, applicantId: number) {
   return res;
 }
 
-export async function deleteRejectApplicant(postId: number, applicantId: number) {
+export async function deleteRejectApplicant({ postId, applicantId }: { postId: number; applicantId: number }) {
   if (!postId) throw new Error("deleteRejectApplicant: postId 또는 accessToken이 유효하지 않습니다.");
   if (!applicantId) throw new Error("deleteRejectApplicant: applicantId가 유효하지 않습니다.");
   const res = await client.delete(`/api/posts/${postId}/applicants/${applicantId}`);

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -36,3 +36,18 @@ export async function putComments({
   });
   return response;
 }
+
+export async function postReply({
+  postId,
+  commentId,
+  content,
+}: {
+  postId: number;
+  commentId: number;
+  content: string;
+}) {
+  const response = await client.post(`/api/posts/${postId}/comments/${commentId}/reply`, {
+    content,
+  });
+  return response;
+}

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -16,3 +16,8 @@ export async function postComments({ id, content }: { id: number; content: strin
   });
   return response;
 }
+
+export async function deleteComments({ postId, commentId }: { postId: number; commentId: number }) {
+  const response = await client.delete(`/api/posts/${postId}/comments/${commentId}`);
+  return response;
+}

--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -21,3 +21,18 @@ export async function deleteComments({ postId, commentId }: { postId: number; co
   const response = await client.delete(`/api/posts/${postId}/comments/${commentId}`);
   return response;
 }
+
+export async function putComments({
+  postId,
+  commentId,
+  content,
+}: {
+  postId: number;
+  commentId: number;
+  content: string;
+}) {
+  const response = await client.put(`/api/posts/${postId}/comments/${commentId}`, {
+    content,
+  });
+  return response;
+}

--- a/src/apis/posts.ts
+++ b/src/apis/posts.ts
@@ -22,3 +22,8 @@ export async function getPostById(id: number) {
   const response = await client.get(`/api/posts/${id}`);
   return response;
 }
+
+export async function deletePost({ id }: { id: number }) {
+  const response = await client.delete(`/api/posts/${id}`);
+  return response;
+}

--- a/src/apis/posts.ts
+++ b/src/apis/posts.ts
@@ -27,3 +27,15 @@ export async function deletePost({ id }: { id: number }) {
   const response = await client.delete(`/api/posts/${id}`);
   return response;
 }
+
+type PutOption = Omit<PostOption, "districtId"> & { id: number };
+
+export async function putPost(putOption: PutOption) {
+  const response = await client.put(`/api/posts/${putOption.id}`, {
+    title: putOption.title,
+    startTime: putOption.startTime,
+    dueTime: putOption.dueTime,
+    content: putOption.content,
+  });
+  return response;
+}

--- a/src/app/@modal/[...close_modal]/page.tsx
+++ b/src/app/@modal/[...close_modal]/page.tsx
@@ -1,0 +1,3 @@
+export default function CloseModalPage() {
+  return null;
+}

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,10 +1,11 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
 import CreatePostForm from "@/components/organisms/CreatePostForm";
 
 function CreateHome() {
   return (
-    <div className="mt-8 p-16 bg-white lg:mx-28">
+    <BackArrowContainer>
       <CreatePostForm />
-    </div>
+    </BackArrowContainer>
   );
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import NavigationBar from "@/components/molecules/NavigationBar";
 import Providers from "@/stores/provider";
 import { Noto_Sans_KR } from "next/font/google";
 import InnerContainer from "@/components/atoms/InnerContainer";
-import Provider from "@/utils/provider";
+import QueryProvider from "@/utils/queryProvider";
 
 const notoSans = Noto_Sans_KR({
   weight: ["100", "300", "400", "500", "700", "900"],
@@ -28,13 +28,13 @@ export default function RootLayout({ children, modal }: { children: React.ReactN
 
       <body className={`bg-[#F6F6F6] ${notoSans.className}`}>
         <Providers>
-          <Provider>
+          <QueryProvider>
             <NavigationBar />
             <Background>
               <InnerContainer>{children}</InnerContainer>
             </Background>
             {modal}
-          </Provider>
+          </QueryProvider>
         </Providers>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,6 @@ import { BsPen } from "react-icons/bs";
 export default function Home({ searchParams }: PageSearchParams) {
   return (
     <main>
-      <Link href="/user_profile/1">프로필조회</Link>
       <InnerContainer>
         {/* 배너 이미지 추가 */}
         <div className="main-contents flex flex-col gap-2 m-10">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { BsPen } from "react-icons/bs";
 export default function Home({ searchParams }: PageSearchParams) {
   return (
     <main>
+      <Link href="/user_profile/1">프로필조회</Link>
       <InnerContainer>
         {/* 배너 이미지 추가 */}
         <div className="main-contents flex flex-col gap-2 m-10">

--- a/src/app/post/[id]/edit/page.tsx
+++ b/src/app/post/[id]/edit/page.tsx
@@ -1,0 +1,18 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
+import PostEditForm from "@/components/organisms/PostEditForm";
+
+interface Props {
+  params: {
+    id: string;
+  };
+}
+
+function PostEditHome({ params }: Props) {
+  return (
+    <BackArrowContainer>
+      <PostEditForm id={params.id} />
+    </BackArrowContainer>
+  );
+}
+
+export default PostEditHome;

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,3 +1,4 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
 import PostTemplates from "@/components/templates/PostTemplates";
 import React from "react";
 
@@ -9,9 +10,9 @@ interface Props {
 
 function PostHome({ params }: Props) {
   return (
-    <div className="mt-8 p-16 bg-white lg:mx-28">
+    <BackArrowContainer>
       <PostTemplates id={params.id} />
-    </div>
+    </BackArrowContainer>
   );
 }
 

--- a/src/app/scoreboard/[user_id]/page.tsx
+++ b/src/app/scoreboard/[user_id]/page.tsx
@@ -1,0 +1,12 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
+import ScoreboardTemplate from "@/components/templates/ScoreboardTemplate";
+
+function ScoreboardPage() {
+  return (
+    <BackArrowContainer>
+      <ScoreboardTemplate />
+    </BackArrowContainer>
+  );
+}
+
+export default ScoreboardPage;

--- a/src/components/atoms/AuthCheckBox/index.tsx
+++ b/src/components/atoms/AuthCheckBox/index.tsx
@@ -6,7 +6,7 @@ interface Props {
   onChange: (isChecked: boolean) => void;
 }
 
-function AuthCheckbox({ checked, onChange }: Props) {
+function AuthCheckbox({ checked, onChange }: Props): JSX.Element {
   return (
     <button
       type="button"

--- a/src/components/atoms/AuthCheckBox/index.tsx
+++ b/src/components/atoms/AuthCheckBox/index.tsx
@@ -13,13 +13,17 @@ function AuthCheckbox({ checked, onChange }: Props) {
       className="flex items-center space-x-2 text-sm cursor-pointer"
       onClick={() => onChange(!checked)}
     >
-      {checked ? <AiFillCheckCircle color="#2196F3" size={16} /> : <AiOutlineCheckCircle color="#2196F3" size={16} />}
+      {checked ? (
+        <AiFillCheckCircle className="text-[#2196F3] text-base" />
+      ) : (
+        <AiOutlineCheckCircle className="text-[#2196F3] text-base" />
+      )}
       &nbsp;번개볼링의&nbsp;
-      <Link href="/service-terms" style={{ color: "#2196F3", textDecoration: "underline" }}>
+      <Link href="/service-terms" className="text-[#2196F3] underline">
         서비스 이용 약관
       </Link>
       &nbsp;및&nbsp;
-      <Link href="/privacy-policy" style={{ color: "#2196F3", textDecoration: "underline" }}>
+      <Link href="/privacy-policy" className="text-[#2196F3] underline">
         개인 정보 수집 및 이용
       </Link>
       에 동의합니다.

--- a/src/components/atoms/AuthInput/index.tsx
+++ b/src/components/atoms/AuthInput/index.tsx
@@ -6,7 +6,7 @@ interface InputProps {
   type: string;
   placeholder: string;
   className: string;
-  onInputChange: (value: any) => void;
+  onInputChange: (value: string) => void;
 }
 
 function AuthInput({ type, placeholder, className, onInputChange }: InputProps) {

--- a/src/components/atoms/AuthInput/index.tsx
+++ b/src/components/atoms/AuthInput/index.tsx
@@ -42,12 +42,8 @@ function AuthInput({ type, placeholder, className, onInputChange }: InputProps) 
         {isPasswordField && (
           <button
             type="button"
-            className="absolute top-2 right-2 text-gray-600 hover:text-gray-800 cursor-pointer"
+            className="w-6 h-6 absolute top-2 right-2 text-gray-600 hover:text-gray-800 cursor-pointer"
             onClick={toggleVisibility}
-            style={{
-              width: "24px",
-              height: "24px",
-            }}
           >
             {isVisible ? <AiOutlineEye /> : <AiOutlineEyeInvisible />}
           </button>

--- a/src/components/atoms/AuthInput/index.tsx
+++ b/src/components/atoms/AuthInput/index.tsx
@@ -9,7 +9,7 @@ interface InputProps {
   onInputChange: (value: string) => void;
 }
 
-function AuthInput({ type, placeholder, className, onInputChange }: InputProps) {
+function AuthInput({ type, placeholder, className, onInputChange }: InputProps): JSX.Element {
   const [isVisible, setIsVisible] = useState(false);
   const [value, setValue] = useState("");
 

--- a/src/components/atoms/BackArrowButton/index.tsx
+++ b/src/components/atoms/BackArrowButton/index.tsx
@@ -9,7 +9,7 @@ function BackArrowButton() {
     router.refresh();
     router.back();
   };
-  return <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />;
+  return <MdArrowBack onClick={handleBack} className="w-[30px] h-[30px] cursor-pointer" />;
 }
 
 export default BackArrowButton;

--- a/src/components/atoms/BackArrowButton/index.tsx
+++ b/src/components/atoms/BackArrowButton/index.tsx
@@ -7,7 +7,7 @@ function BackArrowButton() {
   const router = useRouter();
   const handleBack = () => {
     router.refresh();
-    router.push("/");
+    router.back();
   };
   return <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />;
 }

--- a/src/components/atoms/BackArrowButton/index.tsx
+++ b/src/components/atoms/BackArrowButton/index.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { MdArrowBack } from "react-icons/md";
 
-function BackArrowButton() {
+function BackArrowButton(): JSX.Element {
   const router = useRouter();
   const handleBack = () => {
     router.refresh();

--- a/src/components/atoms/BackArrowButton/index.tsx
+++ b/src/components/atoms/BackArrowButton/index.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { MdArrowBack } from "react-icons/md";
+
+function BackArrowButton() {
+  const router = useRouter();
+  const handleBack = () => {
+    router.refresh();
+    router.push("/");
+  };
+  return <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />;
+}
+
+export default BackArrowButton;

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -4,7 +4,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-function BackArrowContainer({ children }: Props) {
+function BackArrowContainer({ children }: Props): JSX.Element {
   return (
     <div className="mt-8 p-16 bg-white lg:mx-28">
       <BackArrowButton />

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from "next/navigation";
+import { MdArrowBack } from "react-icons/md";
+
+function BackArrowContainer() {
+  const router = useRouter();
+  const handleBack = () => {
+    router.refresh();
+    router.push("/");
+  };
+  return (
+    <div className="mt-8 p-16 bg-white lg:mx-28">
+      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
+    </div>
+  );
+}
+
+export default BackArrowContainer;

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useRouter } from "next/navigation";
 import { MdArrowBack } from "react-icons/md";
 

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -1,21 +1,13 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-import { MdArrowBack } from "react-icons/md";
+import BackArrowButton from "../BackArrowButton";
 
 interface Props {
   children: React.ReactNode;
 }
 
 function BackArrowContainer({ children }: Props) {
-  const router = useRouter();
-  const handleBack = () => {
-    router.refresh();
-    router.push("/");
-  };
   return (
     <div className="mt-8 p-16 bg-white lg:mx-28">
-      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
+      <BackArrowButton />
       {children}
     </div>
   );

--- a/src/components/atoms/BackArrowContainer/index.tsx
+++ b/src/components/atoms/BackArrowContainer/index.tsx
@@ -3,7 +3,11 @@
 import { useRouter } from "next/navigation";
 import { MdArrowBack } from "react-icons/md";
 
-function BackArrowContainer() {
+interface Props {
+  children: React.ReactNode;
+}
+
+function BackArrowContainer({ children }: Props) {
   const router = useRouter();
   const handleBack = () => {
     router.refresh();
@@ -12,6 +16,7 @@ function BackArrowContainer() {
   return (
     <div className="mt-8 p-16 bg-white lg:mx-28">
       <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
+      {children}
     </div>
   );
 }

--- a/src/components/atoms/Background/index.tsx
+++ b/src/components/atoms/Background/index.tsx
@@ -2,7 +2,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-function Background({ children }: Props) {
+function Background({ children }: Props): JSX.Element {
   return <div className="h-screen pt-16 bg-gray-200 overflow-auto">{children}</div>;
 }
 

--- a/src/components/atoms/Badge/index.tsx
+++ b/src/components/atoms/Badge/index.tsx
@@ -8,7 +8,7 @@ interface Props {
  * Badge 컴포넌트 - 모집중, 마감 표현을 위한 뱃지
  * @param {boolean} isClose - 마감 여부를 불리언(true, false)으로 전달받는다
  */
-function Badge({ isClose }: Props) {
+function Badge({ isClose }: Props): JSX.Element {
   return (
     <span className={`inline-block text-white rounded-full px-3 py-1 ${isClose ? "bg-neutral-400" : "bg-[#37D629]"}`}>
       {isClose ? "마감" : "모집중"}

--- a/src/components/atoms/BlankBar/index.tsx
+++ b/src/components/atoms/BlankBar/index.tsx
@@ -1,5 +1,5 @@
 function BlankBar() {
-  return <p className="pb-[16px]" />;
+  return <div className="pb-[16px]" />;
 }
 
 export default BlankBar;

--- a/src/components/atoms/BlankBar/index.tsx
+++ b/src/components/atoms/BlankBar/index.tsx
@@ -1,4 +1,4 @@
-function BlankBar() {
+function BlankBar(): JSX.Element {
   return <div className="pb-[16px]" />;
 }
 

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  styleType: "white" | "thunder" | "outlined-gray";
+  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
   rounded: "full" | "md";
   size: "lg" | "sm";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -12,6 +12,9 @@ function Button({ styleType, rounded, size, onClick, children, noLineHeight }: P
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
+    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white`,
+    "outlined-blue": `border-blue-400 text-blue-400 bg-white`,
+    "filled-blue": `text-white bg-blue-500`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -6,9 +6,19 @@ interface Props {
   children: React.ReactNode;
   noLineHeight?: boolean;
   fontWeight?: "bold" | "semibold" | "normal";
+  fontSize?: "sm" | "md" | "lg";
 }
 
-function Button({ styleType, rounded, size, onClick, children, noLineHeight, fontWeight = "bold" }: Props) {
+function Button({
+  styleType,
+  rounded,
+  size,
+  onClick,
+  children,
+  noLineHeight,
+  fontWeight = "bold",
+  fontSize = "md",
+}: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -30,13 +40,18 @@ function Button({ styleType, rounded, size, onClick, children, noLineHeight, fon
     semibold: "font-semibold",
     normal: "font-normal",
   };
+  const fontSizeObj = {
+    sm: "text-sm",
+    md: "text-base",
+    lg: "text-lg",
+  };
 
   return (
     <button
       type="button"
       className={`px-2 py-1 ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${
         roundedObj[rounded]
-      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${noLineHeight && "leading-none"}`}
+      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -28,8 +28,8 @@ function Button({
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
-    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white`,
-    "outlined-blue": `border-blue-400 text-blue-400 bg-white`,
+    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
+    "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
     "filled-blue": `text-white bg-blue-500`,
   };
   const sizeObj = {

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -19,16 +19,16 @@ function Button({ styleType, rounded, size, onClick, children, fontWeight = "bol
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
-    "thunder-w-20": "bg-thunder text-white min-w-[80px]",
-    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white min-w-[80px]",
-    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white min-w-[80px]`,
-    "outlined-blue": `border border-blue-400 text-blue-400 bg-white min-w-[80px]`,
-    "filled-blue": `border text-white bg-blue-500 min-w-[80px]`,
+    "thunder-w-20": "bg-thunder text-white",
+    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
+    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
+    "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
+    "filled-blue": `border text-white bg-blue-500`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",
     sm: "px-2 py-1",
-    xs: "px-2 py-[3px] leading-none text-sm",
+    xs: "px-2 py-[3px] leading-none text-sm min-w-[80px]",
   };
   const roundedObj = {
     full: "rounded-full",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,40 +1,34 @@
 export interface ButtonProps {
-  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
+  styleType:
+    | "white"
+    | "thunder"
+    | "thunder-w-20"
+    | "outlined-gray"
+    | "outlined-orange"
+    | "outlined-blue"
+    | "filled-blue";
   rounded: "full" | "md";
-  size: "lg" | "sm";
+  size: "lg" | "sm" | "xs";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
-  noLineHeight?: boolean;
   fontWeight?: "bold" | "semibold" | "normal";
-  fontSize?: "sm" | "md" | "lg";
-  padding?: "px-2_py-1" | "px-2_py-[3px]";
-  minWidth?: "70px";
 }
 
-function Button({
-  styleType,
-  rounded,
-  size,
-  onClick,
-  children,
-  noLineHeight,
-  fontWeight = "bold",
-  fontSize = "md",
-  padding = "px-2_py-1",
-  minWidth,
-}: ButtonProps) {
+function Button({ styleType, rounded, size, onClick, children, fontWeight = "bold" }: ButtonProps) {
   const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
-    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
-    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
-    "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
-    "filled-blue": `border text-white bg-blue-500`,
+    "thunder-w-20": "bg-thunder text-white min-w-[80px]",
+    "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white min-w-[80px]",
+    "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white min-w-[80px]`,
+    "outlined-blue": `border border-blue-400 text-blue-400 bg-white min-w-[80px]`,
+    "filled-blue": `border text-white bg-blue-500 min-w-[80px]`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",
-    sm: "",
+    sm: "px-2 py-1",
+    xs: "px-2 py-[3px] leading-none text-sm",
   };
   const roundedObj = {
     full: "rounded-full",
@@ -45,26 +39,11 @@ function Button({
     semibold: "font-semibold",
     normal: "font-normal",
   };
-  const fontSizeObj = {
-    sm: "text-sm",
-    md: "text-base",
-    lg: "text-lg",
-  };
-  const paddingObj = {
-    "px-2_py-1": "px-2 py-1",
-    "px-2_py-[3px]": "px-2 py-[3px]",
-  };
-  const minWidthObj = {
-    "70px": "min-w-[70px]",
-  };
 
   return (
     <button
       type="button"
-      className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${
-        fontWeightObj[fontWeight]
-      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${minWidth && minWidthObj[minWidth]} ${
-        noLineHeight && "leading-none"
+      className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${fontWeightObj[fontWeight]} 
       }`}
       onClick={onClick}
     >

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -4,9 +4,10 @@ interface Props {
   size: "lg" | "sm";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
+  noLineHeight?: boolean;
 }
 
-function Button({ styleType, rounded, size, onClick, children }: Props) {
+function Button({ styleType, rounded, size, onClick, children, noLineHeight }: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -24,7 +25,9 @@ function Button({ styleType, rounded, size, onClick, children }: Props) {
   return (
     <button
       type="button"
-      className={`px-2 py-1 ring-gray-400 ring-inset font-bold filter hover:brightness-95 ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]}`}
+      className={`px-2 py-1 ring-gray-400 ring-inset font-bold filter hover:brightness-95 ${styleObj[styleType]} ${
+        roundedObj[rounded]
+      } ${sizeObj[size]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -21,6 +21,7 @@ function Button({
   fontSize = "md",
   padding = "px-2_py-1",
 }: Props) {
+  const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -55,9 +56,9 @@ function Button({
   return (
     <button
       type="button"
-      className={`ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${roundedObj[rounded]} ${
-        sizeObj[size]
-      } ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
+      className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${
+        fontWeightObj[fontWeight]
+      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,4 +1,4 @@
-interface Props {
+export interface ButtonProps {
   styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
   rounded: "full" | "md";
   size: "lg" | "sm";
@@ -22,7 +22,7 @@ function Button({
   fontSize = "md",
   padding = "px-2_py-1",
   minWidth,
-}: Props) {
+}: ButtonProps) {
   const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,5 +1,5 @@
 export interface ButtonProps {
-  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
+  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue" | "filled-red";
   rounded: "full" | "md";
   size: "lg" | "sm" | "xs";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -16,6 +16,7 @@ function Button({ styleType, rounded, size, onClick, children, fontWeight = "bol
     "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
     "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
     "filled-blue": `border text-white bg-blue-500`,
+    "filled-red": "bg-[#FF2E2E] text-white",
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -8,6 +8,7 @@ interface Props {
   fontWeight?: "bold" | "semibold" | "normal";
   fontSize?: "sm" | "md" | "lg";
   padding?: "px-2_py-1" | "px-2_py-[3px]";
+  minWidth?: "70px";
 }
 
 function Button({
@@ -20,6 +21,7 @@ function Button({
   fontWeight = "bold",
   fontSize = "md",
   padding = "px-2_py-1",
+  minWidth,
 }: Props) {
   const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
@@ -52,13 +54,18 @@ function Button({
     "px-2_py-1": "px-2 py-1",
     "px-2_py-[3px]": "px-2 py-[3px]",
   };
+  const minWidthObj = {
+    "70px": "min-w-[70px]",
+  };
 
   return (
     <button
       type="button"
       className={`${commonStyle} ${styleObj[styleType]} ${roundedObj[rounded]} ${sizeObj[size]} ${
         fontWeightObj[fontWeight]
-      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
+      } ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${minWidth && minWidthObj[minWidth]} ${
+        noLineHeight && "leading-none"
+      }`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -30,7 +30,7 @@ function Button({
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
     "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
     "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,
-    "filled-blue": `text-white bg-blue-500`,
+    "filled-blue": `border text-white bg-blue-500`,
   };
   const sizeObj = {
     lg: "w-[546px] h-[40px] text-xl",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,12 +1,5 @@
 export interface ButtonProps {
-  styleType:
-    | "white"
-    | "thunder"
-    | "thunder-w-20"
-    | "outlined-gray"
-    | "outlined-orange"
-    | "outlined-blue"
-    | "filled-blue";
+  styleType: "white" | "thunder" | "outlined-gray" | "outlined-orange" | "outlined-blue" | "filled-blue";
   rounded: "full" | "md";
   size: "lg" | "sm" | "xs";
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -19,7 +12,6 @@ function Button({ styleType, rounded, size, onClick, children, fontWeight = "bol
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
-    "thunder-w-20": "bg-thunder text-white",
     "outlined-gray": "border border-neutral-400 text-neutral-400 bg-white",
     "outlined-orange": `border border-thunderOrange text-thunderOrange bg-white`,
     "outlined-blue": `border border-blue-400 text-blue-400 bg-white`,

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -7,7 +7,7 @@ export interface ButtonProps {
   fontWeight?: "bold" | "semibold" | "normal";
 }
 
-function Button({ styleType, rounded, size, onClick, children, fontWeight = "bold" }: ButtonProps) {
+function Button({ styleType, rounded, size, onClick, children, fontWeight = "bold" }: ButtonProps): JSX.Element {
   const commonStyle = "ring-gray-400 ring-inset filter hover:brightness-95";
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -5,9 +5,10 @@ interface Props {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
   noLineHeight?: boolean;
+  fontWeight?: "bold" | "semibold" | "normal";
 }
 
-function Button({ styleType, rounded, size, onClick, children, noLineHeight }: Props) {
+function Button({ styleType, rounded, size, onClick, children, noLineHeight, fontWeight = "bold" }: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
     thunder: "bg-thunder text-white",
@@ -24,13 +25,18 @@ function Button({ styleType, rounded, size, onClick, children, noLineHeight }: P
     full: "rounded-full",
     md: "rounded-md",
   };
+  const fontWeightObj = {
+    bold: "font-bold",
+    semibold: "font-semibold",
+    normal: "font-normal",
+  };
 
   return (
     <button
       type="button"
-      className={`px-2 py-1 ring-gray-400 ring-inset font-bold filter hover:brightness-95 ${styleObj[styleType]} ${
+      className={`px-2 py-1 ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${
         roundedObj[rounded]
-      } ${sizeObj[size]} ${noLineHeight && "leading-none"}`}
+      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -7,6 +7,7 @@ interface Props {
   noLineHeight?: boolean;
   fontWeight?: "bold" | "semibold" | "normal";
   fontSize?: "sm" | "md" | "lg";
+  padding?: "px-2_py-1" | "px-2_py-[3px]";
 }
 
 function Button({
@@ -18,6 +19,7 @@ function Button({
   noLineHeight,
   fontWeight = "bold",
   fontSize = "md",
+  padding = "px-2_py-1",
 }: Props) {
   const styleObj = {
     white: "text-gray-600 ring-1 bg-white",
@@ -45,13 +47,17 @@ function Button({
     md: "text-base",
     lg: "text-lg",
   };
+  const paddingObj = {
+    "px-2_py-1": "px-2 py-1",
+    "px-2_py-[3px]": "px-2 py-[3px]",
+  };
 
   return (
     <button
       type="button"
-      className={`px-2 py-1 ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${
-        roundedObj[rounded]
-      } ${sizeObj[size]} ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${noLineHeight && "leading-none"}`}
+      className={`ring-gray-400 ring-inset filter hover:brightness-95 ${styleObj[styleType]} ${roundedObj[rounded]} ${
+        sizeObj[size]
+      } ${fontWeightObj[fontWeight]} ${fontSizeObj[fontSize]} ${paddingObj[padding]} ${noLineHeight && "leading-none"}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/atoms/CircularProfileImage/index.tsx
+++ b/src/components/atoms/CircularProfileImage/index.tsx
@@ -19,7 +19,7 @@ interface Props {
  * sm: "w-6 h-6",
  * 기본 사이즈는 'md': 32*32px이다.
  */
-function CircularProfileImage({ src, styleType = "md" }: Props) {
+function CircularProfileImage({ src, styleType = "md" }: Props): JSX.Element {
   const styles = {
     huge: "w-20 h-20",
     lg: "w-10 h-10",

--- a/src/components/atoms/Dropdown/index.tsx
+++ b/src/components/atoms/Dropdown/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   selectedOptionId?: number;
 }
 
-function Dropdown({ options, onChange, placeholder, styleType, selectedOptionId = -1 }: Props) {
+function Dropdown({ options, onChange, placeholder, styleType, selectedOptionId = -1 }: Props): JSX.Element {
   const styleObj = {
     small: "rounded-full text-center p-1 w-[150px]",
     big: "rounded-3xl p-4 w-[180px] text-xl text-center shadow-lg",

--- a/src/components/atoms/Dropdown/index.tsx
+++ b/src/components/atoms/Dropdown/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   selectedOptionId?: number;
 }
 
-function Dropdown({ options, onChange, placeholder, styleType, selectedOptionId }: Props) {
+function Dropdown({ options, onChange, placeholder, styleType, selectedOptionId = -1 }: Props) {
   const styleObj = {
     small: "rounded-full text-center p-1 w-[150px]",
     big: "rounded-3xl p-4 w-[180px] text-xl text-center shadow-lg",
@@ -17,7 +17,7 @@ function Dropdown({ options, onChange, placeholder, styleType, selectedOptionId 
     <select
       onChange={onChange}
       className={`border text-neutral-500 appearance-none ${styleObj[styleType]}`}
-      value={typeof selectedOptionId !== undefined ? selectedOptionId : -1}
+      value={selectedOptionId}
     >
       <option key="placeholder" value={-1} hidden disabled>
         {placeholder}

--- a/src/components/atoms/InnerContainer/index.tsx
+++ b/src/components/atoms/InnerContainer/index.tsx
@@ -2,7 +2,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-function InnerContainer({ children }: Props) {
+function InnerContainer({ children }: Props): JSX.Element {
   return <div className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">{children}</div>;
 }
 

--- a/src/components/atoms/LoadingSpinner/index.tsx
+++ b/src/components/atoms/LoadingSpinner/index.tsx
@@ -2,7 +2,7 @@ interface Prop {
   styleType?: "xl" | "lg" | "md" | "sm";
 }
 
-function LoadingSpinner({ styleType = "md" }: Prop) {
+function LoadingSpinner({ styleType = "md" }: Prop): JSX.Element {
   const tailwindKeyword = {
     xl: "w-14 h-14",
     lg: "w-10 h-10",

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { MdClose } from "react-icons/md";
 
@@ -10,8 +10,6 @@ interface Props {
 }
 
 function Modal({ children, noPadding }: Props) {
-  const overlay = useRef(null);
-  const wrapper = useRef(null);
   const router = useRouter();
 
   const onDismiss = useCallback(() => {
@@ -31,9 +29,8 @@ function Modal({ children, noPadding }: Props) {
   }, [onKeyDown]);
 
   return (
-    <div ref={overlay} className="fixed z-10 left-0 right-0 top-0 bottom-0 flex items-center justify-center ">
+    <div className="fixed z-10 left-0 right-0 top-0 bottom-0 flex items-center justify-center ">
       <div
-        ref={wrapper}
         className={`relative bg-white rounded-2xl border-[#868484] shadow-2xl overflow-clip ${
           noPadding ? "p-0" : "p-6"
         }`}

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -9,7 +9,7 @@ interface Props {
   noPadding?: boolean;
 }
 
-function Modal({ children, noPadding }: Props) {
+function Modal({ children, noPadding }: Props): JSX.Element {
   const router = useRouter();
 
   const onDismiss = useCallback(() => {

--- a/src/components/atoms/OptionTitle/index.tsx
+++ b/src/components/atoms/OptionTitle/index.tsx
@@ -2,7 +2,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-function OptionTitle({ children }: Props) {
+function OptionTitle({ children }: Props): JSX.Element {
   return <div className="my-4 font-bold text-xl">{children}</div>;
 }
 

--- a/src/components/atoms/Participant/index.tsx
+++ b/src/components/atoms/Participant/index.tsx
@@ -4,7 +4,7 @@ interface Props {
   currentNumber: number;
 }
 
-function Participant({ currentNumber }: Props) {
+function Participant({ currentNumber }: Props): JSX.Element {
   return (
     <span className="text-sm mx-2 font-bold">
       <MdPeopleAlt className="inline mr-1 text-neutral-400" />

--- a/src/components/atoms/RecordSummary/index.tsx
+++ b/src/components/atoms/RecordSummary/index.tsx
@@ -7,7 +7,7 @@ interface Props {
     minimum: number;
   };
 }
-function RecordSummary({ data }: Props) {
+function RecordSummary({ data }: Props): JSX.Element {
   return (
     <div className="record-summary grid gap-[5%] grid-cols-2 md:grid-cols-4 sm">
       <Card text="Game" number={data.game} />

--- a/src/components/atoms/RecordSummary/index.tsx
+++ b/src/components/atoms/RecordSummary/index.tsx
@@ -1,17 +1,19 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 interface Props {
-  game: 20;
-  average: 160;
-  maximum: 180;
-  minimum: 110;
+  data: {
+    game: number;
+    average: number;
+    maximum: number;
+    minimum: number;
+  };
 }
-function RecordSummary({ game, average, maximum, minimum }: Props) {
+function RecordSummary({ data }: Props) {
   return (
     <div className="record-summary grid gap-[5%] grid-cols-2 md:grid-cols-4 sm">
-      <Card text="Game" number={game} />
-      <Card text="Average" number={average} />
-      <Card text="Maximum" number={maximum} />
-      <Card text="Minimum" number={minimum} />
+      <Card text="Game" number={data.game} />
+      <Card text="Average" number={data.average} />
+      <Card text="Maximum" number={data.maximum} />
+      <Card text="Minimum" number={data.minimum} />
     </div>
   );
 }

--- a/src/components/atoms/RecordSummary/index.tsx
+++ b/src/components/atoms/RecordSummary/index.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+interface Props {
+  game: 20;
+  average: 160;
+  maximum: 180;
+  minimum: 110;
+}
+function RecordSummary({ game, average, maximum, minimum }: Props) {
+  return (
+    <div className="record-summary grid gap-[5%] grid-cols-2 md:grid-cols-4 sm">
+      <Card text="Game" number={game} />
+      <Card text="Average" number={average} />
+      <Card text="Maximum" number={maximum} />
+      <Card text="Minimum" number={minimum} />
+    </div>
+  );
+}
+
+export default RecordSummary;
+
+function Card({ text, number }: { text: string; number: number }) {
+  return (
+    <div className="card relative min-h-[80px] rounded-md shadow-lg bg-white py-1 px-2">
+      <span className="text-sm leading-none">{text}</span>
+      <span className="text-xl font-semibold absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+        {number}
+      </span>
+    </div>
+  );
+}

--- a/src/components/atoms/SearchedLocationDisplay/index.tsx
+++ b/src/components/atoms/SearchedLocationDisplay/index.tsx
@@ -26,7 +26,7 @@ function SearchedLocationDisplay({ searchParams }: PageSearchParams) {
 
   return (
     <p className="searched-location flex items-center">
-      <MdLocationOn className="inline text-red-500" size={20} />
+      <MdLocationOn className="inline text-red-500 w-5 h-5" size={20} />
       {searchedRegion}
     </p>
   );

--- a/src/components/atoms/SearchedLocationDisplay/index.tsx
+++ b/src/components/atoms/SearchedLocationDisplay/index.tsx
@@ -4,7 +4,7 @@ import useRegionQueries from "@/hooks/useRegionQueries";
 import { PageSearchParams } from "@/types/pageSearchParams";
 import { MdLocationOn } from "react-icons/md";
 
-function SearchedLocationDisplay({ searchParams }: PageSearchParams) {
+function SearchedLocationDisplay({ searchParams }: PageSearchParams): JSX.Element {
   const cityId = searchParams?.cityId ? parseInt(searchParams?.cityId, 10) || 0 : 0;
   const countryId = searchParams?.countryId ? parseInt(searchParams?.countryId, 10) || 0 : 0;
   const districtId = searchParams?.districtId ? parseInt(searchParams?.districtId, 10) || 0 : 0;

--- a/src/components/atoms/SearchedLocationDisplay/index.tsx
+++ b/src/components/atoms/SearchedLocationDisplay/index.tsx
@@ -16,10 +16,9 @@ function SearchedLocationDisplay({ searchParams }: PageSearchParams) {
   const districts = queries[2]?.data?.data?.response?.districts || [];
 
   const cityName = cities.filter((option: { id: number; name: string }) => option.id === cityId)[0]?.name || "전체";
-  const countryName =
-    countries.filter((option: { id: number; name: string }) => option.id === countryId)[0]?.name || "전체";
+  const countryName = countries.find((option: { id: number; name: string }) => option.id === countryId)?.name || "전체";
   const districtName =
-    districts.filter((option: { id: number; name: string }) => option.id === districtId)[0]?.name || "전체";
+    districts.find((option: { id: number; name: string }) => option.id === districtId)?.name || "전체";
 
   const searchedRegion = `${cityName} ${cityName !== "전체" ? countryName : ""} ${
     cityName !== "전체" && countryName !== "전체" ? districtName : ""

--- a/src/components/molecules/ApplicantBlock/index.tsx
+++ b/src/components/molecules/ApplicantBlock/index.tsx
@@ -25,7 +25,7 @@ function ApplicantBlock({ postId, applicantData }: Prop): JSX.Element {
 
   const handleReject = useCallback(async () => {
     try {
-      await deleteRejectApplicant(postId, applicantId);
+      await deleteRejectApplicant({ postId, applicantId });
       setApprovalStatus("rejected");
     } catch {
       alert("거절 요청이 실패했습니다.");

--- a/src/components/molecules/ApplicantBlock/index.tsx
+++ b/src/components/molecules/ApplicantBlock/index.tsx
@@ -14,26 +14,23 @@ function ApplicantBlock({ postId, applicantData }: Prop) {
   const { user, status: isAccept, id: applicantId } = applicantData;
   const [approvalStatus, setApprovalStatus] = useState(isAccept ? "accepted" : "pending");
 
-  const handleAcceptReject = useCallback(
-    async (type: "accept" | "reject") => {
-      if (type === "accept") {
-        try {
-          await putAcceptApplicant(postId, applicantId);
-          setApprovalStatus("accepted");
-        } catch {
-          alert("수락 요청이 실패했습니다.");
-        }
-      } else {
-        try {
-          await deleteRejectApplicant(postId, applicantId);
-          setApprovalStatus("rejected");
-        } catch {
-          alert("거절 요청이 실패했습니다.");
-        }
-      }
-    },
-    [postId, applicantId],
-  );
+  const handleAccept = useCallback(async () => {
+    try {
+      await putAcceptApplicant(postId, applicantId);
+      setApprovalStatus("accepted");
+    } catch {
+      alert("수락 요청이 실패했습니다.");
+    }
+  }, [postId, applicantId]);
+
+  const handleReject = useCallback(async () => {
+    try {
+      await deleteRejectApplicant(postId, applicantId);
+      setApprovalStatus("rejected");
+    } catch {
+      alert("거절 요청이 실패했습니다.");
+    }
+  }, [postId, applicantId]);
 
   return (
     <div className="applicant flex items-center justify-between border rounded-2xl py-2 px-4">
@@ -61,10 +58,10 @@ function ApplicantBlock({ postId, applicantData }: Prop) {
         )}
         {approvalStatus === "pending" && (
           <>
-            <Button styleType="outlined-gray" size="sm" rounded="full" onClick={() => handleAcceptReject("reject")}>
+            <Button styleType="outlined-gray" size="sm" rounded="full" onClick={() => handleReject()}>
               <span className="block text-sm font-normal min-w-[40px] leading-none fontsize">거절</span>
             </Button>
-            <Button styleType="thunder" size="sm" rounded="full" onClick={() => handleAcceptReject("accept")}>
+            <Button styleType="thunder" size="sm" rounded="full" onClick={() => handleAccept()}>
               <span className="block text-sm font-normal min-w-[40px]">수락</span>
             </Button>
           </>

--- a/src/components/molecules/ApplicantBlock/index.tsx
+++ b/src/components/molecules/ApplicantBlock/index.tsx
@@ -10,7 +10,7 @@ interface Prop {
   applicantData: Applicant;
 }
 
-function ApplicantBlock({ postId, applicantData }: Prop) {
+function ApplicantBlock({ postId, applicantData }: Prop): JSX.Element {
   const { user, status: isAccept, id: applicantId } = applicantData;
   const [approvalStatus, setApprovalStatus] = useState(isAccept ? "accepted" : "pending");
 

--- a/src/components/molecules/ApplyButton/index.tsx
+++ b/src/components/molecules/ApplyButton/index.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { deleteRejectApplicant, getCheckStatus, postApply } from "@/apis/applicant";
+import Button from "@/components/atoms/Button";
+import { getCookie } from "@/utils/Cookie";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+
+interface Props {
+  postId: number;
+  authorId: number;
+}
+
+function ApplyButton({ postId, authorId }: Props): JSX.Element {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const router = useRouter();
+
+  const { data } = useQuery([`/api/posts${postId}/applicants/check-status`, postId], () => getCheckStatus(postId));
+
+  const { mutate: applyMutate } = useMutation({ mutationFn: postApply });
+  const { mutate: deleteMutate } = useMutation({ mutationFn: deleteRejectApplicant });
+
+  const [isApplied, setIsApplied] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsApplied(data?.data?.response.isApplied);
+  }, [data]);
+
+  const handleApply = () => {
+    applyMutate(postId, {
+      onSuccess: () => {
+        setIsApplied(true);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
+  const handleDeleteApply = () => {
+    deleteMutate(
+      { postId, applicantId: userId },
+      {
+        onSuccess: () => {
+          setIsApplied(false);
+        },
+        onError: (error) => {
+          console.log(error);
+        },
+      },
+    );
+  };
+
+  if (authorId === userId) {
+    return (
+      <Button
+        styleType="thunder"
+        rounded="md"
+        size="sm"
+        onClick={() => {
+          router.push(`/applicant_confirm/${postId}`, { scroll: false });
+        }}
+      >
+        신청자 확인
+      </Button>
+    );
+  }
+  if (isApplied) {
+    return (
+      <Button styleType="filled-red" rounded="md" size="sm" onClick={handleDeleteApply}>
+        신청취소
+      </Button>
+    );
+  }
+  return (
+    <Button styleType="thunder" rounded="md" size="sm" onClick={handleApply}>
+      신청하기
+    </Button>
+  );
+}
+
+export default ApplyButton;

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   childComment: CommentData;
 }
 
-function ChildComment({ childComment }: Props) {
+function ChildComment({ childComment }: Props): JSX.Element {
   return (
     <>
       <div className="flex items-center gap-3">

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -1,10 +1,8 @@
-import { MdOutlineSubdirectoryArrowRight, MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
+import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
 import React from "react";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
-import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
-import { deleteComments } from "@/apis/comment";
-import { getCookie } from "@/utils/Cookie";
+import CommentBlock from "../CommentBlock";
 
 interface Props {
   childComment: CommentData;
@@ -12,50 +10,13 @@ interface Props {
 }
 
 function ChildComment({ childComment, id }: Props) {
-  const userId = parseInt(getCookie("userId"), 10);
-
-  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
-
-  const handleDeleteComment = () => {
-    const payload = {
-      postId: id,
-      commentId: childComment.id,
-    };
-    mutate(payload, {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["/comments", id]);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    });
-  };
-
   return (
     <>
       <div className="flex items-center gap-3">
         <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <div className="flex items-center justify-between">
-            <span className="text-[#2a5885]">{childComment.userName}</span>
-            <div className="flex items-center gap-2 text-neutral-400 text-sm">
-              {childComment.userId === userId && (
-                <>
-                  <button type="button" className="flex items-center cursor-pointer">
-                    <MdOutlineEdit />
-                    수정
-                  </button>
-                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
-                    <MdOutlineDelete />
-                    삭제
-                  </button>
-                </>
-              )}
-              <span>답글 달기</span>
-            </div>
-          </div>
-          <pre className="whitespace-pre-wrap break-all">{childComment.content}</pre>
+          <CommentBlock comment={childComment} id={id} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -15,7 +15,7 @@ function ChildComment({ childComment }: Props) {
         <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={childComment} />
+          <CommentBlock comment={childComment} isChild={false} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -6,17 +6,16 @@ import CommentBlock from "../CommentBlock";
 
 interface Props {
   childComment: CommentData;
-  id: number;
 }
 
-function ChildComment({ childComment, id }: Props) {
+function ChildComment({ childComment }: Props) {
   return (
     <>
       <div className="flex items-center gap-3">
         <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={childComment} id={id} />
+          <CommentBlock comment={childComment} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -42,10 +42,10 @@ function ChildComment({ childComment, id }: Props) {
             <div className="flex items-center gap-2 text-neutral-400 text-sm">
               {childComment.userId === userId && (
                 <>
-                  <span className="flex items-center cursor-pointer">
+                  <button type="button" className="flex items-center cursor-pointer">
                     <MdOutlineEdit />
                     수정
-                  </span>
+                  </button>
                   <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
                     <MdOutlineDelete />
                     삭제

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -12,7 +12,7 @@ function ChildComment({ childComment }: Props) {
   return (
     <>
       <div className="flex items-center gap-3">
-        <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
+        <MdOutlineSubdirectoryArrowRight className="w-8 h-8 text-neutral-400" />
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
           <CommentBlock comment={childComment} isChild={false} />

--- a/src/components/molecules/ChildComment/index.tsx
+++ b/src/components/molecules/ChildComment/index.tsx
@@ -1,13 +1,36 @@
-import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
+import { MdOutlineSubdirectoryArrowRight, MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import React from "react";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { deleteComments } from "@/apis/comment";
+import { getCookie } from "@/utils/Cookie";
 
 interface Props {
   childComment: CommentData;
+  id: number;
 }
 
-function ChildComment({ childComment }: Props) {
+function ChildComment({ childComment, id }: Props) {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
+
+  const handleDeleteComment = () => {
+    const payload = {
+      postId: id,
+      commentId: childComment.id,
+    };
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
   return (
     <>
       <div className="flex items-center gap-3">
@@ -16,8 +39,20 @@ function ChildComment({ childComment }: Props) {
         <div className="flex-1">
           <div className="flex items-center justify-between">
             <span className="text-[#2a5885]">{childComment.userName}</span>
-            <div className="text-neutral-400">
-              <span className="text-sm">답글 달기</span>
+            <div className="flex items-center gap-2 text-neutral-400 text-sm">
+              {childComment.userId === userId && (
+                <>
+                  <span className="flex items-center cursor-pointer">
+                    <MdOutlineEdit />
+                    수정
+                  </span>
+                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
+                    <MdOutlineDelete />
+                    삭제
+                  </button>
+                </>
+              )}
+              <span>답글 달기</span>
             </div>
           </div>
           <pre className="whitespace-pre-wrap break-all">{childComment.content}</pre>

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -64,7 +64,9 @@ function Comment({ comment, id }: Props) {
       </div>
       <hr className="mt-2" />
       {comment.childComments &&
-        comment.childComments.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
+        comment.childComments.map((childComment) => (
+          <ChildComment childComment={childComment} key={childComment.id} id={id} />
+        ))}
     </>
   );
 }

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -63,7 +63,7 @@ function Comment({ comment }: Props) {
         <>
           <div className="flex items-center gap-1">
             <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
-            <p>대댓글 등록</p>
+            <p>답글 달기</p>
           </div>
           <div className="flex items-center gap-3 mt-2">
             <CommentSubmit

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -17,7 +17,7 @@ interface Props {
   comment: CommentWithChild;
 }
 
-function Comment({ comment }: Props) {
+function Comment({ comment }: Props): JSX.Element {
   const params = useParams();
   const id = parseInt(params.id as string, 10);
 

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -27,8 +27,7 @@ function Comment({ comment }: Props) {
         </div>
       </div>
       <hr className="mt-2" />
-      {comment.childComments &&
-        comment.childComments.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
+      {comment.childComments?.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
     </>
   );
 }

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -1,13 +1,8 @@
-import React, { useRef, useState } from "react";
-import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
+import React from "react";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
-import { getCookie } from "@/utils/Cookie";
-import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
-import { deleteComments, putComments } from "@/apis/comment";
-import { useMutation } from "@tanstack/react-query";
 import ChildComment from "../ChildComment";
-import CommentSubmit from "../CommentSubmit";
+import CommentBlock from "../CommentBlock";
 
 export interface CommentWithChild extends CommentData {
   childComments: CommentData[];
@@ -19,86 +14,12 @@ interface Props {
 }
 
 function Comment({ comment, id }: Props) {
-  const userId = parseInt(getCookie("userId"), 10);
-
-  const [update, setUpdate] = useState(false);
-  const [commentContent, setCommentContent] = useState(comment.content);
-
-  const commentRef = useRef<HTMLTextAreaElement>(null);
-
-  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
-  const { mutate: putMutate } = useMutation(putComments);
-
-  const payload = {
-    postId: id,
-    commentId: comment.id,
-  };
-
-  const handleDeleteComment = () => {
-    mutate(payload, {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["/comments", id]);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    });
-  };
-  const handleUpdateForm = () => {
-    setUpdate((prev) => !prev);
-    setCommentContent(comment.content);
-  };
-  const handleUpdate = () => {
-    const putPayload = {
-      ...payload,
-      content: commentContent,
-    };
-    putMutate(putPayload, {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["/comments", id]);
-        setUpdate(false);
-      },
-      onError: (error) => {
-        console.log(error);
-      },
-    });
-  };
-
   return (
     <>
       <div className="flex items-center gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <div className="flex items-center justify-between">
-            <span className="text-[#2a5885]">{comment.userName}</span>
-            <div className="flex items-center gap-2 text-neutral-400 text-sm">
-              {comment.userId === userId && (
-                <>
-                  <button type="button" onClick={handleUpdateForm} className="flex items-center cursor-pointer">
-                    <MdOutlineEdit />
-                    수정
-                  </button>
-                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
-                    <MdOutlineDelete />
-                    삭제
-                  </button>
-                </>
-              )}
-              <span>답글 달기</span>
-            </div>
-          </div>
-          {update ? (
-            <div className="flex items-center gap-3 mt-2">
-              <CommentSubmit
-                commentRef={commentRef}
-                onClick={handleUpdate}
-                value={commentContent}
-                setValue={setCommentContent}
-              />
-            </div>
-          ) : (
-            <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>
-          )}
+          <CommentBlock comment={comment} id={id} />
         </div>
       </div>
       <hr className="mt-2" />

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -10,23 +10,20 @@ export interface CommentWithChild extends CommentData {
 
 interface Props {
   comment: CommentWithChild;
-  id: number;
 }
 
-function Comment({ comment, id }: Props) {
+function Comment({ comment }: Props) {
   return (
     <>
       <div className="flex items-center gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={comment} id={id} />
+          <CommentBlock comment={comment} />
         </div>
       </div>
       <hr className="mt-2" />
       {comment.childComments &&
-        comment.childComments.map((childComment) => (
-          <ChildComment childComment={childComment} key={childComment.id} id={id} />
-        ))}
+        comment.childComments.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
     </>
   );
 }

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -62,7 +62,7 @@ function Comment({ comment }: Props) {
       {reply && (
         <>
           <div className="flex items-center gap-1">
-            <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
+            <MdOutlineSubdirectoryArrowRight className="h-8 w-8 text-neutral-400" />
             <p>답글 달기</p>
           </div>
           <div className="flex items-center gap-3 mt-2">

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -1,8 +1,13 @@
-import React from "react";
+import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
+import React, { useRef, useState } from "react";
+import { useParams } from "next/navigation";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
-import ChildComment from "../ChildComment";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { postReply } from "@/apis/comment";
 import CommentBlock from "../CommentBlock";
+import ChildComment from "../ChildComment";
+import CommentSubmit from "../CommentSubmit";
 
 export interface CommentWithChild extends CommentData {
   childComments: CommentData[];
@@ -13,15 +18,64 @@ interface Props {
 }
 
 function Comment({ comment }: Props) {
+  const params = useParams();
+  const id = parseInt(params.id as string, 10);
+
+  const [reply, setReply] = useState(false);
+  const [commentContent, setCommentContent] = useState("");
+
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(postReply);
+
+  const handleReplyForm = () => {
+    setReply((prev) => !prev);
+    setCommentContent("");
+  };
+
+  const handleReply = () => {
+    const payload = {
+      postId: id,
+      commentId: comment.id,
+      content: commentContent,
+    };
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+        setReply(false);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
   return (
     <>
       <div className="flex items-center gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <div className="flex-1">
-          <CommentBlock comment={comment} />
+          <CommentBlock comment={comment} isChild handleReplyForm={handleReplyForm} />
         </div>
       </div>
       <hr className="mt-2" />
+      {reply && (
+        <>
+          <div className="flex items-center gap-1">
+            <MdOutlineSubdirectoryArrowRight size="32" className="text-neutral-400" />
+            <p>대댓글 등록</p>
+          </div>
+          <div className="flex items-center gap-3 mt-2">
+            <CommentSubmit
+              commentRef={commentRef}
+              onClick={handleReply}
+              value={commentContent}
+              setValue={setCommentContent}
+            />
+          </div>
+          <hr className="mt-2" />
+        </>
+      )}
       {comment.childComments &&
         comment.childComments.map((childComment) => <ChildComment childComment={childComment} key={childComment.id} />)}
     </>

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -1,6 +1,10 @@
 import React from "react";
+import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import { CommentData } from "@/types/commentData";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import { getCookie } from "@/utils/Cookie";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { deleteComments } from "@/apis/comment";
 import ChildComment from "../ChildComment";
 
 export interface CommentWithChild extends CommentData {
@@ -9,9 +13,29 @@ export interface CommentWithChild extends CommentData {
 
 interface Props {
   comment: CommentWithChild;
+  id: number;
 }
 
-function Comment({ comment }: Props) {
+function Comment({ comment, id }: Props) {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
+
+  const handleDeleteComment = () => {
+    const payload = {
+      postId: id,
+      commentId: comment.id,
+    };
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
   return (
     <>
       <div className="flex items-center gap-3">
@@ -19,8 +43,20 @@ function Comment({ comment }: Props) {
         <div className="flex-1">
           <div className="flex items-center justify-between">
             <span className="text-[#2a5885]">{comment.userName}</span>
-            <div className="text-neutral-400">
-              <span className="text-sm">답글 달기</span>
+            <div className="flex items-center gap-2 text-neutral-400 text-sm">
+              {comment.userId === userId && (
+                <>
+                  <span className="flex items-center cursor-pointer">
+                    <MdOutlineEdit />
+                    수정
+                  </span>
+                  <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
+                    <MdOutlineDelete />
+                    삭제
+                  </button>
+                </>
+              )}
+              <span>답글 달기</span>
             </div>
           </div>
           <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -10,9 +10,11 @@ import CommentSubmit from "../CommentSubmit";
 
 interface Props {
   comment: CommentData;
+  isChild: boolean;
+  handleReplyForm?: any;
 }
 
-function CommentBlock({ comment }: Props) {
+function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
   const userId = parseInt(getCookie("userId"), 10);
   const params = useParams();
   const id = parseInt(params.id as string, 10);
@@ -79,7 +81,11 @@ function CommentBlock({ comment }: Props) {
               </button>
             </>
           )}
-          <span>답글 달기</span>
+          {isChild && (
+            <button type="button" onClick={handleReplyForm}>
+              답글 달기
+            </button>
+          )}
         </div>
       </div>
       {update ? (

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -1,6 +1,6 @@
 import { CommentData } from "@/types/commentData";
 import { getCookie } from "@/utils/Cookie";
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { deleteComments, putComments } from "@/apis/comment";
@@ -11,7 +11,7 @@ import CommentSubmit from "../CommentSubmit";
 interface Props {
   comment: CommentData;
   isChild: boolean;
-  handleReplyForm?: any;
+  handleReplyForm?: () => void;
 }
 
 function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
@@ -21,8 +21,6 @@ function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
 
   const [update, setUpdate] = useState(false);
   const [commentContent, setCommentContent] = useState(comment.content);
-
-  const commentRef = useRef<HTMLTextAreaElement>(null);
 
   const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
   const { mutate: putMutate } = useMutation(putComments);
@@ -90,12 +88,7 @@ function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
       </div>
       {update ? (
         <div className="flex items-center gap-3 mt-2">
-          <CommentSubmit
-            commentRef={commentRef}
-            onClick={handleUpdate}
-            value={commentContent}
-            setValue={setCommentContent}
-          />
+          <CommentSubmit onClick={handleUpdate} value={commentContent} setValue={setCommentContent} />
         </div>
       ) : (
         <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -1,0 +1,99 @@
+import { CommentData } from "@/types/commentData";
+import { getCookie } from "@/utils/Cookie";
+import React, { useRef, useState } from "react";
+import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
+import { deleteComments, putComments } from "@/apis/comment";
+import { useMutation } from "@tanstack/react-query";
+import CommentSubmit from "../CommentSubmit";
+
+interface Props {
+  comment: CommentData;
+  id: number;
+}
+
+function CommentBlock({ comment, id }: Props) {
+  const userId = parseInt(getCookie("userId"), 10);
+
+  const [update, setUpdate] = useState(false);
+  const [commentContent, setCommentContent] = useState(comment.content);
+
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  const { mutate, queryClient } = useMutateWithQueryClient(deleteComments);
+  const { mutate: putMutate } = useMutation(putComments);
+
+  const payload = {
+    postId: id,
+    commentId: comment.id,
+  };
+
+  const handleUpdateForm = () => {
+    setUpdate((prev) => !prev);
+    setCommentContent(comment.content);
+  };
+
+  const handleDeleteComment = () => {
+    mutate(payload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
+  const handleUpdate = () => {
+    const putPayload = {
+      ...payload,
+      content: commentContent,
+    };
+    putMutate(putPayload, {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["/comments", id]);
+        setUpdate(false);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    });
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <span className="text-[#2a5885]">{comment.userName}</span>
+        <div className="flex items-center gap-2 text-neutral-400 text-sm">
+          {comment.userId === userId && (
+            <>
+              <button type="button" onClick={handleUpdateForm} className="flex items-center cursor-pointer">
+                <MdOutlineEdit />
+                수정
+              </button>
+              <button type="button" onClick={handleDeleteComment} className="flex items-center cursor-pointer">
+                <MdOutlineDelete />
+                삭제
+              </button>
+            </>
+          )}
+          <span>답글 달기</span>
+        </div>
+      </div>
+      {update ? (
+        <div className="flex items-center gap-3 mt-2">
+          <CommentSubmit
+            commentRef={commentRef}
+            onClick={handleUpdate}
+            value={commentContent}
+            setValue={setCommentContent}
+          />
+        </div>
+      ) : (
+        <pre className="whitespace-pre-wrap break-all">{comment.content}</pre>
+      )}
+    </>
+  );
+}
+
+export default CommentBlock;

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -5,15 +5,17 @@ import { MdOutlineEdit, MdOutlineDelete } from "react-icons/md";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { deleteComments, putComments } from "@/apis/comment";
 import { useMutation } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
 import CommentSubmit from "../CommentSubmit";
 
 interface Props {
   comment: CommentData;
-  id: number;
 }
 
-function CommentBlock({ comment, id }: Props) {
+function CommentBlock({ comment }: Props) {
   const userId = parseInt(getCookie("userId"), 10);
+  const params = useParams();
+  const id = parseInt(params.id as string, 10);
 
   const [update, setUpdate] = useState(false);
   const [commentContent, setCommentContent] = useState(comment.content);

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   handleReplyForm?: () => void;
 }
 
-function CommentBlock({ comment, isChild, handleReplyForm }: Props) {
+function CommentBlock({ comment, isChild, handleReplyForm }: Props): JSX.Element {
   const userId = parseInt(getCookie("userId"), 10);
   const params = useParams();
   const id = parseInt(params.id as string, 10);

--- a/src/components/molecules/CommentSubmit/index.tsx
+++ b/src/components/molecules/CommentSubmit/index.tsx
@@ -3,30 +3,37 @@ import { MdSend } from "react-icons/md";
 
 interface Props {
   commentRef: React.RefObject<HTMLTextAreaElement>;
+  value?: string;
+  setValue?: React.Dispatch<React.SetStateAction<string>>;
   onClick: () => void;
 }
 
-function CommentSubmit({ commentRef, onClick }: Props) {
-  const currentRef = commentRef.current;
+function CommentSubmit({ commentRef, value, setValue, onClick }: Props) {
+  const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const textarea = e.target;
 
-  const handleResize = () => {
-    if (currentRef!.clientHeight >= 86) {
-      currentRef!.style.overflowY = "auto";
-    } else {
-      currentRef!.style.overflowY = "hidden";
+    if (setValue) {
+      setValue(textarea.value);
     }
-    currentRef!.style.height = "auto";
-    currentRef!.style.height = `${currentRef!.scrollHeight}px`;
+
+    if (textarea.clientHeight >= 86) {
+      textarea.style.overflowY = "auto";
+    } else {
+      textarea.style.overflowY = "hidden";
+    }
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
   };
 
   return (
     <>
       <textarea
-        className="resize-none w-5/6 h-[40px] max-h-[88px] py-2 px-3 rounded-lg border border-gray-400 overflow-y-hidden"
+        className="resize-none flex-1 h-[40px] max-h-[88px] py-2 px-3 rounded-lg border border-gray-400 overflow-y-hidden"
         placeholder="내용을 입력해 주세요."
         rows={1}
         ref={commentRef}
-        onInput={handleResize}
+        value={value}
+        onChange={handleOnChange}
       />
       <MdSend size="36" className="text-neutral-400 cursor-pointer" onClick={onClick} />
     </>

--- a/src/components/molecules/CommentSubmit/index.tsx
+++ b/src/components/molecules/CommentSubmit/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { MdSend } from "react-icons/md";
 
 interface Props {
-  commentRef: React.RefObject<HTMLTextAreaElement>;
+  commentRef?: React.RefObject<HTMLTextAreaElement>;
   value?: string;
   setValue?: React.Dispatch<React.SetStateAction<string>>;
   onClick: () => void;

--- a/src/components/molecules/CommentSubmit/index.tsx
+++ b/src/components/molecules/CommentSubmit/index.tsx
@@ -35,7 +35,7 @@ function CommentSubmit({ commentRef, value, setValue, onClick }: Props) {
         value={value}
         onChange={handleOnChange}
       />
-      <MdSend size="36" className="text-neutral-400 cursor-pointer" onClick={onClick} />
+      <MdSend className="w-9 h-9 text-neutral-400 cursor-pointer" onClick={onClick} />
     </>
   );
 }

--- a/src/components/molecules/CommentSubmit/index.tsx
+++ b/src/components/molecules/CommentSubmit/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   onClick: () => void;
 }
 
-function CommentSubmit({ commentRef, value, setValue, onClick }: Props) {
+function CommentSubmit({ commentRef, value, setValue, onClick }: Props): JSX.Element {
   const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const textarea = e.target;
 

--- a/src/components/molecules/DatePicker/index.tsx
+++ b/src/components/molecules/DatePicker/index.tsx
@@ -15,7 +15,7 @@ interface Props {
   setValue: React.Dispatch<SetStateAction<Date | null>>;
 }
 
-function DatePicker({ title, value, setValue }: Props) {
+function DatePicker({ title, value, setValue }: Props): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
   const [isTimeOpen, setIsTimeOpen] = useState(false);
 

--- a/src/components/molecules/DropdownBox/index.tsx
+++ b/src/components/molecules/DropdownBox/index.tsx
@@ -20,7 +20,7 @@ interface Props {
   styleType: "big" | "small";
 }
 
-function DropdownBox({ styleType, selectedOptionIds, setSelectedOptionIds }: Props) {
+function DropdownBox({ styleType, selectedOptionIds, setSelectedOptionIds }: Props): JSX.Element {
   const queries = useRegionQueries({ cityId: selectedOptionIds.cityId, countryId: selectedOptionIds.countryId });
 
   const options1 = queries[0]?.data?.data?.response?.cities || [];

--- a/src/components/molecules/InputBox/index.tsx
+++ b/src/components/molecules/InputBox/index.tsx
@@ -21,7 +21,7 @@ function InputBox({ inputs, onInputChange }: Props) {
           type={input.type}
           placeholder={input.placeholder}
           className={input.className}
-          onInputChange={(value: any) => onInputChange(input.type, value)} // Pass input value to parent component
+          onInputChange={(value: string) => onInputChange(input.type, value)} // Pass input value to parent component
         />
       ))}
     </div>

--- a/src/components/molecules/InputBox/index.tsx
+++ b/src/components/molecules/InputBox/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   onInputChange: (fieldName: string, value: string) => void; // Include onInputChange prop here
 }
 
-function InputBox({ inputs, onInputChange }: Props) {
+function InputBox({ inputs, onInputChange }: Props): JSX.Element {
   return (
     <div>
       {inputs.map((input, index) => (

--- a/src/components/molecules/MiniProfile/index.tsx
+++ b/src/components/molecules/MiniProfile/index.tsx
@@ -7,7 +7,7 @@ interface Prop {
   userName: string;
 }
 
-function MiniProfile({ userId, imageSrc, userName }: Prop) {
+function MiniProfile({ userId, imageSrc, userName }: Prop): JSX.Element {
   return (
     <Link href={`/user_profile/${userId}`} className="inline-flex gap-1 items-center">
       <CircularProfileImage src={imageSrc} />

--- a/src/components/molecules/MiniProfile/index.tsx
+++ b/src/components/molecules/MiniProfile/index.tsx
@@ -5,13 +5,15 @@ interface Prop {
   userId: number;
   imageSrc: string | null;
   userName: string;
+  size?: "md" | "sm";
 }
 
-function MiniProfile({ userId, imageSrc, userName }: Prop): JSX.Element {
+function MiniProfile({ userId, imageSrc, userName, size = "md" }: Prop): JSX.Element {
+  const fontSize = { md: "text-xl", sm: "text-base" };
   return (
     <Link href={`/user_profile/${userId}`} className="inline-flex gap-1 items-center">
-      <CircularProfileImage src={imageSrc} />
-      <span className="user-name text-xl">{userName}</span>
+      <CircularProfileImage src={imageSrc} styleType={size} />
+      <span className={`user-name ${fontSize[size]}`}>{userName}</span>
     </Link>
   );
 }

--- a/src/components/molecules/MiniProfile/index.tsx
+++ b/src/components/molecules/MiniProfile/index.tsx
@@ -1,0 +1,19 @@
+import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import Link from "next/link";
+
+interface Prop {
+  userId: number;
+  imageSrc: string | null;
+  userName: string;
+}
+
+function MiniProfile({ userId, imageSrc, userName }: Prop) {
+  return (
+    <Link href={`/user_profile/${userId}`} className="inline-flex gap-1 items-center">
+      <CircularProfileImage src={imageSrc} />
+      <span className="user-name text-xl">{userName}</span>
+    </Link>
+  );
+}
+
+export default MiniProfile;

--- a/src/components/molecules/NavigationBar/index.tsx
+++ b/src/components/molecules/NavigationBar/index.tsx
@@ -12,7 +12,7 @@ import { useEffect } from "react";
 import { setLogin, getTokenPayload, deleteToken } from "@/utils/user";
 import { postAuthentication } from "@/apis/sign";
 
-function NavigationBar() {
+function NavigationBar(): JSX.Element {
   const router = useRouter();
   const dispatch = useAppDispatch();
   const expiryDate = useAppSelector((state) => state.expiryDate);

--- a/src/components/molecules/PostCard/index.tsx
+++ b/src/components/molecules/PostCard/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   data: PostData;
 }
 
-function PostCard({ data }: Props) {
+function PostCard({ data }: Props): JSX.Element {
   return (
     <Link
       href={`/post/${data.id}`}

--- a/src/components/molecules/PostEditor/index.tsx
+++ b/src/components/molecules/PostEditor/index.tsx
@@ -29,7 +29,13 @@ function PostEditor({ id }: Props) {
 
   return (
     <div className="flex text-neutral-500 gap-3">
-      <button type="button" className="flex items-center cursor-pointer">
+      <button
+        type="button"
+        className="flex items-center cursor-pointer"
+        onClick={() => {
+          router.push(`/post/${id}/edit`);
+        }}
+      >
         <MdOutlineEdit />
         수정
       </button>

--- a/src/components/molecules/PostEditor/index.tsx
+++ b/src/components/molecules/PostEditor/index.tsx
@@ -14,7 +14,7 @@ function PostEditor({ id }: Props) {
 
   const handleDelete = () => {
     mutate(
-      { id: id },
+      { id },
       {
         onSuccess: () => {
           router.refresh();
@@ -29,14 +29,14 @@ function PostEditor({ id }: Props) {
 
   return (
     <div className="flex text-neutral-500 gap-3">
-      <span className="flex items-center cursor-pointer">
+      <button type="button" className="flex items-center cursor-pointer">
         <MdOutlineEdit />
         수정
-      </span>
-      <span className="flex items-center cursor-pointer" onClick={handleDelete}>
+      </button>
+      <button type="button" className="flex items-center cursor-pointer" onClick={handleDelete}>
         <MdOutlineDelete />
         삭제
-      </span>
+      </button>
     </div>
   );
 }

--- a/src/components/molecules/PostEditor/index.tsx
+++ b/src/components/molecules/PostEditor/index.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { MdOutlineDelete, MdOutlineEdit } from "react-icons/md";
+import { deletePost } from "@/apis/posts";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  id: number;
+}
+
+function PostEditor({ id }: Props) {
+  const { mutate } = useMutation(deletePost);
+  const router = useRouter();
+
+  const handleDelete = () => {
+    mutate(
+      { id: id },
+      {
+        onSuccess: () => {
+          router.refresh();
+          router.push("/");
+        },
+        onError: (error) => {
+          console.log(error);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="flex text-neutral-500 gap-3">
+      <span className="flex items-center cursor-pointer">
+        <MdOutlineEdit />
+        수정
+      </span>
+      <span className="flex items-center cursor-pointer" onClick={handleDelete}>
+        <MdOutlineDelete />
+        삭제
+      </span>
+    </div>
+  );
+}
+
+export default PostEditor;

--- a/src/components/molecules/PostFilter/index.tsx
+++ b/src/components/molecules/PostFilter/index.tsx
@@ -3,7 +3,7 @@
 import { PageSearchParams } from "@/types/pageSearchParams";
 import { usePathname, useRouter } from "next/navigation";
 
-function PostFilter({ searchParams }: PageSearchParams) {
+function PostFilter({ searchParams }: PageSearchParams): JSX.Element {
   const pathname = usePathname();
   const searchParamsState = new URLSearchParams(searchParams);
   const isAll = searchParamsState.get("all") !== "false";

--- a/src/components/molecules/PostFilter/index.tsx
+++ b/src/components/molecules/PostFilter/index.tsx
@@ -2,23 +2,14 @@
 
 import { PageSearchParams } from "@/types/pageSearchParams";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 
 function PostFilter({ searchParams }: PageSearchParams) {
   const pathname = usePathname();
-  const [searchParamsState, setSearchParamsState] = useState(new URLSearchParams(searchParams));
-  const [isAll, setIsAll] = useState(searchParamsState.get("all") !== "false");
+  const searchParamsState = new URLSearchParams(searchParams);
+  const isAll = searchParamsState.get("all") !== "false";
   const router = useRouter();
 
-  useEffect(() => {
-    setSearchParamsState(new URLSearchParams(searchParams));
-  }, [searchParams]);
-  useEffect(() => {
-    setIsAll(searchParamsState.get("all") !== "false");
-  }, [searchParamsState]);
-
   const handleOnClick = (newIsAll: boolean) => {
-    setIsAll(newIsAll);
     searchParamsState.set("all", newIsAll.toString());
     const queryString = searchParamsState.toString();
     router.push(`${pathname}?${queryString}`);

--- a/src/components/molecules/PostList/index.tsx
+++ b/src/components/molecules/PostList/index.tsx
@@ -59,7 +59,7 @@ function PostList({ searchParams }: PageSearchParams) {
     if (target.current) {
       observer.observe(target.current);
     }
-    return () => observer && observer.disconnect();
+    return () => observer.disconnect();
   }, [target, data, observer]);
 
   return (

--- a/src/components/molecules/PostList/index.tsx
+++ b/src/components/molecules/PostList/index.tsx
@@ -5,6 +5,8 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { PostData } from "@/types/postData";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { getPosts } from "@/apis/posts";
+import objectToQueryString from "@/utils/objectToQueryString";
+import { PostSearchParam } from "@/types/postSearchParam";
 import PostCard from "../PostCard";
 
 function PostList({ searchParams }: PageSearchParams) {
@@ -13,9 +15,12 @@ function PostList({ searchParams }: PageSearchParams) {
     const countryId = parseInt(URLSearchParams.get("countryId") || "0", 10);
     const districtId = parseInt(URLSearchParams.get("districtId") || "0", 10);
     const all = URLSearchParams.get("all");
-    const queryString = `?${cityId > 0 ? `cityId=${cityId}` : ""}${countryId > 0 ? `&countryId=${countryId}` : ""}${
-      districtId > 0 ? `&districtId=${districtId}` : ""
-    }${all === "true" || all === "false" ? `&all=${all}` : ""}`;
+    const queryParams: PostSearchParam = {};
+    if (cityId) queryParams.cityId = cityId;
+    if (countryId) queryParams.countryId = countryId;
+    if (districtId) queryParams.districtId = districtId;
+    if (all === "true" || all === "false") queryParams.all = all as string;
+    const queryString = objectToQueryString(queryParams as Record<string, string | number>);
     return getPosts(`${queryString}${pageParam ? `&key=${pageParam}` : ""}`);
   };
 

--- a/src/components/molecules/PostList/index.tsx
+++ b/src/components/molecules/PostList/index.tsx
@@ -9,7 +9,7 @@ import objectToQueryString from "@/utils/objectToQueryString";
 import { PostSearchParam } from "@/types/postSearchParam";
 import PostCard from "../PostCard";
 
-function PostList({ searchParams }: PageSearchParams) {
+function PostList({ searchParams }: PageSearchParams): JSX.Element {
   const getPostList = async ({ pageParam = 0 }, URLSearchParams: URLSearchParams) => {
     const cityId = parseInt(URLSearchParams.get("cityId") || "0", 10);
     const countryId = parseInt(URLSearchParams.get("countryId") || "0", 10);

--- a/src/components/molecules/PostList/index.tsx
+++ b/src/components/molecules/PostList/index.tsx
@@ -20,8 +20,9 @@ function PostList({ searchParams }: PageSearchParams) {
     if (countryId) queryParams.countryId = countryId;
     if (districtId) queryParams.districtId = districtId;
     if (all === "true" || all === "false") queryParams.all = all as string;
+    if (pageParam) queryParams.key = pageParam;
     const queryString = objectToQueryString(queryParams as Record<string, string | number>);
-    return getPosts(`${queryString}${pageParam ? `&key=${pageParam}` : ""}`);
+    return getPosts(queryString);
   };
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -1,0 +1,5 @@
+function RecordCard() {
+  return <div>RecordCard</div>;
+}
+
+export default RecordCard;

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -43,12 +43,7 @@ function RecordCard({ data }: Props) {
         <RecordTimeWithLocation districtName={data.districtName} startTime={data.startTime} />
         <div className="scores">
           {scores.map((score) => (
-            <ScoreWithImageButton
-              key={`${data.id}:${score.id}`}
-              scoreId={score.id}
-              score={score.score}
-              scoreImage={score.scoreImage}
-            />
+            <ScoreWithImageButton key={`${data.id}:${score.id}`} scoreObj={score} />
           ))}
         </div>
         <div className="expand-button-with-member-image flex w-full justify-between items-center">
@@ -95,19 +90,11 @@ function RecordTimeWithLocation({ districtName, startTime }: { districtName: str
   );
 }
 
-function ScoreWithImageButton({
-  scoreId,
-  score,
-  scoreImage,
-}: {
-  scoreId: number;
-  score: number;
-  scoreImage: string | null;
-}) {
+function ScoreWithImageButton({ scoreObj }: { scoreObj: { id: number; score: number; scoreImage: string | null } }) {
   return (
     <div className="score flex gap-2">
-      <span>{`스코어 ${scoreId} | ${score}`}</span>
-      {scoreImage && (
+      <span>{`스코어 ${scoreObj.id} | ${scoreObj.score}`}</span>
+      {scoreObj.scoreImage && (
         <button
           type="button"
           className="inline-flex items-center gap-x-0.5 border border-thunderOrange text-thunderOrange text-sm rounded-full px-2 py-[3px] bg-white hover:brightness-95"

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -18,7 +18,7 @@ interface Props {
   data: RecordData;
 }
 
-function RecordCard({ data }: Props) {
+function RecordCard({ data }: Props): JSX.Element {
   const params = useParams();
   const [isExpand, setIsExpand] = useState(false);
 

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -1,5 +1,148 @@
-function RecordCard() {
-  return <div>RecordCard</div>;
+"use client";
+
+import Badge from "@/components/atoms/Badge";
+import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import Participant from "@/components/atoms/Participant";
+import { RecordData } from "@/types/recordData";
+import { getCookie } from "@/utils/Cookie";
+import { formatDateToString } from "@/utils/formatDateToString";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
+
+interface Props {
+  data: RecordData;
+}
+
+function RecordCard({ data }: Props) {
+  const params = useParams();
+  const [isExpand, setIsExpand] = useState(false);
+
+  const members = data?.members;
+  const scores = data?.scores;
+  const myId = getCookie("userId");
+  const isMyRecord = myId === parseInt(params.user_id as string, 10);
+
+  return (
+    <div className="record-card flex flex-col gap-6 bg-white p-7 rounded-2xl shadow ">
+      <div className="record-card-upper">
+        <Badge isClose={data.isClose} />
+        <Participant currentNumber={data.currentNumber} />
+        <span className="text-neutral-400">
+          <span className="mr-1">모집마감</span>
+          <span>{formatDateToString(data.dueTime)}</span>
+        </span>
+      </div>
+      <Link href={`/post/${data.id}`} className="record-title-wrapper">
+        <h1 className="record-title text-2xl">{data.title}</h1>
+      </Link>
+      <div className="record-card-lower flex flex-col gap-2">
+        <div className="record-info-wrapper flex gap-4 text-neutral-400">
+          <p className="district-name">
+            <MdLocationPin className="inline" />
+            <span>{data.districtName}</span>
+          </p>
+          <p className="start-time">
+            <MdAlarm className="inline" />
+            <span>{formatDateToString(data.startTime)}</span>
+          </p>
+        </div>
+        <div className="scores">
+          {scores.map((score) => (
+            <div key={`${data.id}:${score.id}`} className="score flex gap-2">
+              <span>{`스코어 ${score.id} | ${score.score}`}</span>
+              {score.scoreImage && (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-x-0.5 border border-thunderOrange text-thunderOrange text-sm rounded-full px-2 py-[3px] bg-white hover:brightness-95"
+                >
+                  <MdCameraAlt className="inline" />
+                  <span className="leading-none">이미지 보기</span>
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="expand-button-with-member-image flex w-full justify-between items-center">
+          <div className="member-image-preview flex gap-2 items-center">
+            {!isExpand &&
+              (members.length > 3 ? (
+                <>
+                  {members.slice(0, 3).map((member) => (
+                    <CircularProfileImage key={member.id} src={member.profileImage} styleType="md" />
+                  ))}
+                  <MdMoreHoriz className="text-neutral-400 w-8 h-8" />
+                </>
+              ) : (
+                members.map((member) => (
+                  <CircularProfileImage key={member.id} src={member.profileImage} styleType="md" />
+                ))
+              ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setIsExpand((prev) => !prev);
+            }}
+          >
+            {isExpand ? (
+              <MdArrowDropUp className="h-12 w-12 hover:scale-125 transition" />
+            ) : (
+              <MdArrowDropDown className="h-12 w-12 hover:scale-125 transition" />
+            )}
+          </button>
+        </div>
+        {isExpand &&
+          (members.length ? (
+            <div className="members grid grid-cols-2 gap-2">
+              {members.map((member) => {
+                const commonButtonStyle =
+                  "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
+                const buttonStyles = {
+                  "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
+                  "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
+                  "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
+                  "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
+                };
+                return (
+                  <div key={`${data.id}:${member.id}`} className="member flex gap-4 items-center">
+                    <Link href={`/user_profile/${member.id}`} className="flex gap-1 items-center">
+                      <CircularProfileImage src={member.profileImage} />
+                      <span className="member-name text-xl">{member.name}</span>
+                    </Link>
+                    {isMyRecord &&
+                      myId === member.id &&
+                      (scores.length ? (
+                        <button type="button" className={buttonStyles["outlined-blue"]}>
+                          수정하기
+                        </button>
+                      ) : (
+                        <button type="button" className={buttonStyles["filled-blue"]}>
+                          점수등록
+                        </button>
+                      ))}
+                    {isMyRecord &&
+                      myId !== member.id &&
+                      (member.isRated ? (
+                        <button type="button" className={buttonStyles["outlined-gray"]}>
+                          완료
+                        </button>
+                      ) : (
+                        <button type="button" className={buttonStyles["outlined-orange"]}>
+                          별점주기
+                        </button>
+                      ))}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <span className="no-member text-center text-2xl text-neutral-400">참여자가 없습니다.</span>
+          ))}
+      </div>
+    </div>
+  );
 }
 
 export default RecordCard;

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -11,7 +11,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Dispatch, SetStateAction, useState } from "react";
 import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
-import MiniProfile from "../MiniProfile";
+import RecordCardMember from "../RecordCardMember";
 
 interface Props {
   data: RecordData;
@@ -56,7 +56,7 @@ function RecordCard({ data }: Props) {
           (members.length ? (
             <div className="members grid grid-cols-2 gap-2">
               {members.map((member) => (
-                <Member
+                <RecordCardMember
                   key={`${data.id}:${member.id}`}
                   clientUserId={clientUserId}
                   isMyRecord={isMyRecord}
@@ -149,58 +149,5 @@ function ExpandButton({
         <MdArrowDropDown className="h-12 w-12 hover:scale-125 transition" />
       )}
     </button>
-  );
-}
-
-function Member({
-  member,
-  isMyRecord,
-  clientUserId,
-  scoresLength,
-}: {
-  member: {
-    id: number;
-    name: string;
-    profileImage: string | null;
-    isRated: boolean;
-  };
-  isMyRecord: boolean;
-  clientUserId: number;
-  scoresLength: number;
-}) {
-  const commonButtonStyle =
-    "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
-  const buttonStyles = {
-    "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
-    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
-    "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
-    "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
-  };
-  return (
-    <div className="member flex gap-4 items-center">
-      <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
-      {isMyRecord &&
-        clientUserId === member.id &&
-        (scoresLength ? (
-          <button type="button" className={buttonStyles["outlined-blue"]}>
-            수정하기
-          </button>
-        ) : (
-          <button type="button" className={buttonStyles["filled-blue"]}>
-            점수등록
-          </button>
-        ))}
-      {isMyRecord &&
-        clientUserId !== member.id &&
-        (member.isRated ? (
-          <button type="button" className={buttonStyles["outlined-gray"]}>
-            완료
-          </button>
-        ) : (
-          <button type="button" className={buttonStyles["outlined-orange"]}>
-            별점주기
-          </button>
-        ))}
-    </div>
   );
 }

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -66,7 +66,7 @@ function RecordCard({ data }: Props) {
                   clientUserId={clientUserId}
                   isMyRecord={isMyRecord}
                   member={member}
-                  scores={scores}
+                  scoresLength={scores.length}
                 />
               ))}
             </div>
@@ -169,7 +169,7 @@ function Member({
   member,
   isMyRecord,
   clientUserId,
-  scores,
+  scoresLength,
 }: {
   member: {
     id: number;
@@ -179,11 +179,7 @@ function Member({
   };
   isMyRecord: boolean;
   clientUserId: number;
-  scores: {
-    id: number;
-    score: number;
-    scoreImage: string | null;
-  }[];
+  scoresLength: number;
 }) {
   const commonButtonStyle =
     "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
@@ -198,7 +194,7 @@ function Member({
       <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
       {isMyRecord &&
         clientUserId === member.id &&
-        (scores.length ? (
+        (scoresLength ? (
           <button type="button" className={buttonStyles["outlined-blue"]}>
             수정하기
           </button>

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Dispatch, SetStateAction, useState } from "react";
 import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
+import Button from "@/components/atoms/Button";
 import RecordCardMember from "../RecordCardMember";
 
 interface Props {
@@ -101,13 +102,12 @@ function ScoreWithImageButton({ scoreObj }: { scoreObj: RecordData["scores"][num
     <div className="score flex gap-2">
       <span>{`스코어 ${scoreObj.id} | ${scoreObj.score}`}</span>
       {scoreObj.scoreImage && (
-        <button
-          type="button"
-          className="inline-flex items-center gap-x-0.5 border border-thunderOrange text-thunderOrange text-sm rounded-full px-2 py-[3px] bg-white hover:brightness-95"
-        >
-          <MdCameraAlt className="inline" />
-          <span className="leading-none">이미지 보기</span>
-        </button>
+        <Button rounded="full" size="xs" styleType="outlined-orange" fontWeight="normal">
+          <div className="inline-flex items-center gap-x-0.5 ">
+            <MdCameraAlt className="inline" />
+            <span className="leading-none">이미지 보기</span>
+          </div>
+        </Button>
       )}
     </div>
   );

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useState } from "react";
 import { MdAlarm, MdLocationPin, MdArrowDropUp, MdArrowDropDown, MdMoreHoriz, MdCameraAlt } from "react-icons/md";
+import MiniProfile from "../MiniProfile";
 
 interface Props {
   data: RecordData;
@@ -107,10 +108,7 @@ function RecordCard({ data }: Props) {
                 };
                 return (
                   <div key={`${data.id}:${member.id}`} className="member flex gap-4 items-center">
-                    <Link href={`/user_profile/${member.id}`} className="flex gap-1 items-center">
-                      <CircularProfileImage src={member.profileImage} />
-                      <span className="member-name text-xl">{member.name}</span>
-                    </Link>
+                    <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
                     {isMyRecord &&
                       myId === member.id &&
                       (scores.length ? (

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -75,7 +75,13 @@ function RecordCard({ data }: Props) {
 
 export default RecordCard;
 
-function RecordTimeWithLocation({ districtName, startTime }: { districtName: string; startTime: Date }) {
+function RecordTimeWithLocation({
+  districtName,
+  startTime,
+}: {
+  districtName: RecordData["districtName"];
+  startTime: RecordData["startTime"];
+}) {
   return (
     <div className="record-info-wrapper flex gap-4 text-neutral-400">
       <p className="district-name">
@@ -90,7 +96,7 @@ function RecordTimeWithLocation({ districtName, startTime }: { districtName: str
   );
 }
 
-function ScoreWithImageButton({ scoreObj }: { scoreObj: { id: number; score: number; scoreImage: string | null } }) {
+function ScoreWithImageButton({ scoreObj }: { scoreObj: RecordData["scores"][number] }) {
   return (
     <div className="score flex gap-2">
       <span>{`스코어 ${scoreObj.id} | ${scoreObj.score}`}</span>
@@ -107,16 +113,7 @@ function ScoreWithImageButton({ scoreObj }: { scoreObj: { id: number; score: num
   );
 }
 
-function MembersImagePreview({
-  members,
-}: {
-  members: {
-    id: number;
-    name: string;
-    profileImage: string | null;
-    isRated: boolean;
-  }[];
-}) {
+function MembersImagePreview({ members }: { members: RecordData["members"] }) {
   return members.length > 3 ? (
     <>
       {members.slice(0, 3).map((member) => (

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import Button, { ButtonProps } from "@/components/atoms/Button";
+import Button from "@/components/atoms/Button";
 import { RecordData } from "@/types/recordData";
 import MiniProfile from "../MiniProfile";
 
@@ -17,43 +17,27 @@ function RecordCardMember({ member, isMyRecord, clientUserId, scoresLength }: Pr
       {isMyRecord &&
         clientUserId === member.id &&
         (scoresLength ? (
-          <MyButton styleType="outlined-blue">수정하기</MyButton>
+          <Button size="xs" rounded="full" styleType="outlined-blue" fontWeight="normal">
+            수정하기
+          </Button>
         ) : (
-          <MyButton styleType="filled-blue">점수등록</MyButton>
+          <Button size="xs" rounded="full" styleType="filled-blue" fontWeight="normal">
+            점수등록
+          </Button>
         ))}
       {isMyRecord &&
         clientUserId !== member.id &&
         (member.isRated ? (
-          <MyButton styleType="outlined-gray">완료</MyButton>
+          <Button size="xs" rounded="full" styleType="outlined-gray" fontWeight="normal">
+            완료
+          </Button>
         ) : (
-          <MyButton styleType="outlined-orange">별점주기</MyButton>
+          <Button size="xs" rounded="full" styleType="outlined-orange" fontWeight="normal">
+            별점주기
+          </Button>
         ))}
     </div>
   );
 }
 
 export default RecordCardMember;
-
-interface MyButtonProp {
-  children: ButtonProps["children"];
-  styleType: ButtonProps["styleType"];
-  onClick?: ButtonProps["onClick"];
-}
-
-function MyButton({ children, styleType, onClick }: MyButtonProp) {
-  return (
-    <Button
-      size="sm"
-      rounded="full"
-      styleType={styleType}
-      fontSize="sm"
-      fontWeight="normal"
-      minWidth="70px"
-      padding="px-2_py-[3px]"
-      noLineHeight
-      onClick={onClick}
-    >
-      {children}
-    </Button>
-  );
-}

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,23 +1,16 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import Button, { ButtonProps } from "@/components/atoms/Button";
+import { RecordData } from "@/types/recordData";
 import MiniProfile from "../MiniProfile";
 
-function RecordCardMember({
-  member,
-  isMyRecord,
-  clientUserId,
-  scoresLength,
-}: {
-  member: {
-    id: number;
-    name: string;
-    profileImage: string | null;
-    isRated: boolean;
-  };
+interface Prop {
+  member: RecordData["members"][number];
   isMyRecord: boolean;
   clientUserId: number;
   scoresLength: number;
-}) {
+}
+
+function RecordCardMember({ member, isMyRecord, clientUserId, scoresLength }: Prop) {
   return (
     <div className="member flex gap-4 items-center">
       <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -10,7 +10,7 @@ interface Prop {
   scoresLength: number;
 }
 
-function RecordCardMember({ member, isMyRecord, clientUserId, scoresLength }: Prop) {
+function RecordCardMember({ member, isMyRecord, clientUserId, scoresLength }: Prop): JSX.Element {
   return (
     <div className="member flex gap-4 items-center">
       <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import Button, { ButtonProps } from "@/components/atoms/Button";
 import MiniProfile from "../MiniProfile";
 
 function RecordCardMember({
@@ -16,41 +18,49 @@ function RecordCardMember({
   clientUserId: number;
   scoresLength: number;
 }) {
-  const commonButtonStyle =
-    "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
-  const buttonStyles = {
-    "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
-    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
-    "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
-    "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
-  };
   return (
     <div className="member flex gap-4 items-center">
       <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
       {isMyRecord &&
         clientUserId === member.id &&
         (scoresLength ? (
-          <button type="button" className={buttonStyles["outlined-blue"]}>
-            수정하기
-          </button>
+          <MyButton styleType="outlined-blue">수정하기</MyButton>
         ) : (
-          <button type="button" className={buttonStyles["filled-blue"]}>
-            점수등록
-          </button>
+          <MyButton styleType="filled-blue">점수등록</MyButton>
         ))}
       {isMyRecord &&
         clientUserId !== member.id &&
         (member.isRated ? (
-          <button type="button" className={buttonStyles["outlined-gray"]}>
-            완료
-          </button>
+          <MyButton styleType="outlined-gray">완료</MyButton>
         ) : (
-          <button type="button" className={buttonStyles["outlined-orange"]}>
-            별점주기
-          </button>
+          <MyButton styleType="outlined-orange">별점주기</MyButton>
         ))}
     </div>
   );
 }
 
 export default RecordCardMember;
+
+interface MyButtonProp {
+  children: ButtonProps["children"];
+  styleType: ButtonProps["styleType"];
+  onClick?: ButtonProps["onClick"];
+}
+
+function MyButton({ children, styleType, onClick }: MyButtonProp) {
+  return (
+    <Button
+      size="sm"
+      rounded="full"
+      styleType={styleType}
+      fontSize="sm"
+      fontWeight="normal"
+      minWidth="70px"
+      padding="px-2_py-[3px]"
+      noLineHeight
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/molecules/RecordCardMember/index.tsx
+++ b/src/components/molecules/RecordCardMember/index.tsx
@@ -1,0 +1,56 @@
+import MiniProfile from "../MiniProfile";
+
+function RecordCardMember({
+  member,
+  isMyRecord,
+  clientUserId,
+  scoresLength,
+}: {
+  member: {
+    id: number;
+    name: string;
+    profileImage: string | null;
+    isRated: boolean;
+  };
+  isMyRecord: boolean;
+  clientUserId: number;
+  scoresLength: number;
+}) {
+  const commonButtonStyle =
+    "h-fit min-w-[70px] border text-sm leading-none rounded-full px-2 py-[3px] hover:brightness-95";
+  const buttonStyles = {
+    "outlined-gray": `border-neutral-400 text-neutral-400 bg-white ${commonButtonStyle}`,
+    "outlined-orange": `border-thunderOrange text-thunderOrange bg-white ${commonButtonStyle}`,
+    "outlined-blue": `border-blue-400 text-blue-400 bg-white ${commonButtonStyle}`,
+    "filled-blue": `text-white bg-blue-500 ${commonButtonStyle}`,
+  };
+  return (
+    <div className="member flex gap-4 items-center">
+      <MiniProfile userId={member.id} userName={member.name} imageSrc={member.profileImage} />
+      {isMyRecord &&
+        clientUserId === member.id &&
+        (scoresLength ? (
+          <button type="button" className={buttonStyles["outlined-blue"]}>
+            수정하기
+          </button>
+        ) : (
+          <button type="button" className={buttonStyles["filled-blue"]}>
+            점수등록
+          </button>
+        ))}
+      {isMyRecord &&
+        clientUserId !== member.id &&
+        (member.isRated ? (
+          <button type="button" className={buttonStyles["outlined-gray"]}>
+            완료
+          </button>
+        ) : (
+          <button type="button" className={buttonStyles["outlined-orange"]}>
+            별점주기
+          </button>
+        ))}
+    </div>
+  );
+}
+
+export default RecordCardMember;

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -41,9 +41,10 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("all");
           }}
-          styleType={condition === "all" ? "thunder" : "outlined-gray"}
+          styleType={condition === "all" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           전체 보기
         </Button>
@@ -51,9 +52,10 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("created");
           }}
-          styleType={condition === "created" ? "thunder" : "outlined-gray"}
+          styleType={condition === "created" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           작성한 글
         </Button>
@@ -61,9 +63,10 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("participated");
           }}
-          styleType={condition === "participated" ? "thunder" : "outlined-gray"}
+          styleType={condition === "participated" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           참여한 글
         </Button>
@@ -73,9 +76,10 @@ function RecordFilter() {
           onClick={() => {
             handleStatus("all");
           }}
-          styleType={status === "all" ? "thunder" : "outlined-gray"}
+          styleType={status === "all" ? "thunder-w-20" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           전체
         </Button>
@@ -86,6 +90,7 @@ function RecordFilter() {
           styleType={status === "closed" ? "thunder" : "outlined-gray"}
           size="sm"
           rounded="full"
+          fontWeight="normal"
         >
           모집 완료
         </Button>

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -41,7 +41,7 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("all");
           }}
-          styleType={condition === "all" ? "thunder-w-20" : "outlined-gray"}
+          styleType={condition === "all" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"
@@ -52,7 +52,7 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("created");
           }}
-          styleType={condition === "created" ? "thunder-w-20" : "outlined-gray"}
+          styleType={condition === "created" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"
@@ -63,7 +63,7 @@ function RecordFilter() {
           onClick={() => {
             handleCondition("participated");
           }}
-          styleType={condition === "participated" ? "thunder-w-20" : "outlined-gray"}
+          styleType={condition === "participated" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"
@@ -76,7 +76,7 @@ function RecordFilter() {
           onClick={() => {
             handleStatus("all");
           }}
-          styleType={status === "all" ? "thunder-w-20" : "outlined-gray"}
+          styleType={status === "all" ? "thunder" : "outlined-gray"}
           size="xs"
           rounded="full"
           fontWeight="normal"

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/atoms/Button";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-function RecordFilter() {
+function RecordFilter(): JSX.Element {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [condition, setCondition] = useState(searchParams.get("condition") || "all");

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -1,0 +1,5 @@
+function RecordFilter() {
+  return <div>RecordFilter</div>;
+}
+
+export default RecordFilter;

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -36,13 +36,13 @@ function RecordFilter() {
 
   return (
     <div className="post-filter flex flex-col gap-2">
-      <div className="post-filter-condition flex w-fit gap-2">
+      <div className="post-filter-condition flex w-fit gap-2 h-7">
         <Button
           onClick={() => {
             handleCondition("all");
           }}
           styleType={condition === "all" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
@@ -53,7 +53,7 @@ function RecordFilter() {
             handleCondition("created");
           }}
           styleType={condition === "created" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
@@ -64,20 +64,20 @@ function RecordFilter() {
             handleCondition("participated");
           }}
           styleType={condition === "participated" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
           참여한 글
         </Button>
       </div>
-      <div className="post-filter-status flex w-fit gap-2">
+      <div className="post-filter-status flex w-fit gap-2 h-7">
         <Button
           onClick={() => {
             handleStatus("all");
           }}
           styleType={status === "all" ? "thunder-w-20" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >
@@ -88,7 +88,7 @@ function RecordFilter() {
             handleStatus("closed");
           }}
           styleType={status === "closed" ? "thunder" : "outlined-gray"}
-          size="sm"
+          size="xs"
           rounded="full"
           fontWeight="normal"
         >

--- a/src/components/molecules/RecordFilter/index.tsx
+++ b/src/components/molecules/RecordFilter/index.tsx
@@ -1,5 +1,97 @@
+"use client";
+
+import Button from "@/components/atoms/Button";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
 function RecordFilter() {
-  return <div>RecordFilter</div>;
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [condition, setCondition] = useState(searchParams.get("condition") || "all");
+  const [status, setStatus] = useState(searchParams.get("status") || "all");
+
+  useEffect(() => {
+    setCondition(searchParams.get("condition") || "all");
+    setStatus(searchParams.get("status") || "all");
+  }, [searchParams]);
+
+  const handleCondition = useCallback(
+    (newCondition: "all" | "created" | "participated") => {
+      const searchParamObj = new URLSearchParams(searchParams);
+      searchParamObj.set("condition", newCondition);
+      const queryString = searchParamObj.toString();
+      router.push(`?${queryString}`);
+    },
+    [router, searchParams],
+  );
+  const handleStatus = useCallback(
+    (newStatus: "all" | "closed") => {
+      const searchParamObj = new URLSearchParams(searchParams);
+      searchParamObj.set("status", newStatus);
+      const queryString = searchParamObj.toString();
+      router.push(`?${queryString}`);
+    },
+    [router, searchParams],
+  );
+
+  return (
+    <div className="post-filter flex flex-col gap-2">
+      <div className="post-filter-condition flex w-fit gap-2">
+        <Button
+          onClick={() => {
+            handleCondition("all");
+          }}
+          styleType={condition === "all" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          전체 보기
+        </Button>
+        <Button
+          onClick={() => {
+            handleCondition("created");
+          }}
+          styleType={condition === "created" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          작성한 글
+        </Button>
+        <Button
+          onClick={() => {
+            handleCondition("participated");
+          }}
+          styleType={condition === "participated" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          참여한 글
+        </Button>
+      </div>
+      <div className="post-filter-status flex w-fit gap-2">
+        <Button
+          onClick={() => {
+            handleStatus("all");
+          }}
+          styleType={status === "all" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          전체
+        </Button>
+        <Button
+          onClick={() => {
+            handleStatus("closed");
+          }}
+          styleType={status === "closed" ? "thunder" : "outlined-gray"}
+          size="sm"
+          rounded="full"
+        >
+          모집 완료
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export default RecordFilter;

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -3,7 +3,7 @@
 import Button from "@/components/atoms/Button";
 import Dropdown from "@/components/atoms/Dropdown";
 
-function RecordSearchBar() {
+function RecordSearchBar(): JSX.Element {
   return (
     <div className="record-search-bar flex gap-4">
       <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "전체 지역" }]} />

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -1,0 +1,5 @@
+function RecordSearchBar() {
+  return <div>RecordSearchBar</div>;
+}
+
+export default RecordSearchBar;

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -12,7 +12,7 @@ function RecordSearchBar() {
         <span className="leading-none">~</span>
         <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "9999년 9월" }]} />
       </div>
-      <Button styleType="thunder-w-20" fontWeight="normal" size="sm" rounded="full">
+      <Button styleType="thunder" fontWeight="normal" size="sm" rounded="full">
         조회
       </Button>
     </div>

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -1,5 +1,22 @@
+"use client";
+
+import Button from "@/components/atoms/Button";
+import Dropdown from "@/components/atoms/Dropdown";
+
 function RecordSearchBar() {
-  return <div>RecordSearchBar</div>;
+  return (
+    <div className="record-search-bar flex gap-4">
+      <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "전체 지역" }]} />
+      <div className="period-dropdown flex gap-2 items-center">
+        <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "1111년 11월" }]} />
+        <span className="leading-none">~</span>
+        <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "9999년 9월" }]} />
+      </div>
+      <Button styleType="thunder" size="sm" rounded="full">
+        조회
+      </Button>
+    </div>
+  );
 }
 
 export default RecordSearchBar;

--- a/src/components/molecules/RecordSearchBar/index.tsx
+++ b/src/components/molecules/RecordSearchBar/index.tsx
@@ -12,7 +12,7 @@ function RecordSearchBar() {
         <span className="leading-none">~</span>
         <Dropdown placeholder="" onChange={() => {}} styleType="small" options={[{ id: 0, name: "9999년 9월" }]} />
       </div>
-      <Button styleType="thunder" size="sm" rounded="full">
+      <Button styleType="thunder-w-20" fontWeight="normal" size="sm" rounded="full">
         조회
       </Button>
     </div>

--- a/src/components/molecules/RegionSearchBar/index.tsx
+++ b/src/components/molecules/RegionSearchBar/index.tsx
@@ -41,7 +41,7 @@ function RegionSearchBar({ searchParams }: PageSearchParams) {
             router.push(`/${queryString}`);
         }}
       >
-        <MdSearch size={28} color="white" className="m-auto" />
+        <MdSearch className="w-7 h-7 text-white m-auto" />
       </button>
     </div>
   );

--- a/src/components/molecules/RegionSearchBar/index.tsx
+++ b/src/components/molecules/RegionSearchBar/index.tsx
@@ -7,7 +7,7 @@ import objectToQueryString from "@/utils/objectToQueryString";
 import { PageSearchParams } from "@/types/pageSearchParams";
 import DropdownBox from "../DropdownBox";
 
-function RegionSearchBar({ searchParams }: PageSearchParams) {
+function RegionSearchBar({ searchParams }: PageSearchParams): JSX.Element {
   const searchParamsToState = useCallback((param: URLSearchParams) => {
     return {
       cityId: !Number.isNaN(parseInt(param.get("cityId")!, 10)) ? parseInt(param.get("cityId")!, 10) : -1,

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -81,7 +81,7 @@ function CommentForm({ id }: Props) {
         {data?.pages?.map(
           (page) =>
             page?.data?.response?.comments.map((comment: CommentWithChild) => (
-              <Comment comment={comment} key={comment.id} id={id} />
+              <Comment comment={comment} key={comment.id} />
             )),
         )}
       </div>

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   id: number;
 }
 
-function CommentForm({ id }: Props) {
+function CommentForm({ id }: Props): JSX.Element {
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
     ["/comments", id],
     ({ pageParam = null }) => getComments(id, pageParam),

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -67,7 +67,7 @@ function CommentForm({ id }: Props) {
     if (target.current) {
       observer.observe(target.current);
     }
-    return () => observer && observer.disconnect();
+    return () => observer.disconnect();
   }, [target, data, observer]);
 
   return (

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -2,10 +2,10 @@
 
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { getComments } from "@/apis/comment";
+import { getComments, postComments } from "@/apis/comment";
 import Comment, { CommentWithChild } from "@/components/molecules/Comment";
 import CommentSubmit from "@/components/molecules/CommentSubmit";
-import useCommentsMutation from "@/hooks/useCommentsMutation";
+import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
 
 interface Props {
@@ -25,7 +25,7 @@ function CommentForm({ id }: Props) {
     },
   );
 
-  const { mutate, queryClient } = useCommentsMutation();
+  const { mutate, queryClient } = useMutateWithQueryClient(postComments);
 
   const commentRef = useRef<HTMLTextAreaElement>(null);
   const target = useRef<HTMLDivElement>(null);
@@ -81,7 +81,7 @@ function CommentForm({ id }: Props) {
         {data?.pages?.map(
           (page) =>
             page?.data?.response?.comments.map((comment: CommentWithChild) => (
-              <Comment comment={comment} key={comment.id} />
+              <Comment comment={comment} key={comment.id} id={id} />
             )),
         )}
       </div>

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -73,7 +73,7 @@ function CommentForm({ id }: Props) {
   return (
     <div>
       <h2 className="mt-4 text-xl">댓글</h2>
-      <div className="mt-6 flex items-center justify-between">
+      <div className="mt-6 flex items-center justify-between gap-3">
         <CircularProfileImage src="/images/default_profile_image.png" styleType="lg" />
         <CommentSubmit commentRef={commentRef} onClick={handleSubmit} />
       </div>

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -8,6 +8,7 @@ import DropdownBox from "@/components/molecules/DropdownBox";
 import { postRegisterPosts } from "@/apis/posts";
 import { useMutation } from "@tanstack/react-query";
 import { formatDateToKoreanTime } from "@/utils/formatDateToString";
+import { useRouter } from "next/navigation";
 
 function CreatePostForm() {
   const [regionIds, setRegionIds] = useState({ cityId: -1, countryId: -1, districtId: -1 });
@@ -17,6 +18,8 @@ function CreatePostForm() {
   const contentRef = useRef<HTMLTextAreaElement>(null);
 
   const errRef = useRef<HTMLParagraphElement>(null);
+
+  const router = useRouter();
 
   const { mutate } = useMutation({ mutationFn: postRegisterPosts });
 

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -52,7 +52,7 @@ function CreatePostForm(): JSX.Element {
       };
       mutate(payload, {
         onSuccess: (res) => {
-          router.push(`/post/${res.data.response.id}`);
+          router.replace(`/post/${res.data.response.id}`);
         },
         onError: (error) => {
           console.log(error);

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -10,7 +10,7 @@ import { useMutation } from "@tanstack/react-query";
 import { formatDateToKoreanTime } from "@/utils/formatDateToString";
 import { useRouter } from "next/navigation";
 
-function CreatePostForm() {
+function CreatePostForm(): JSX.Element {
   const [regionIds, setRegionIds] = useState({ cityId: -1, countryId: -1, districtId: -1 });
   const [startTime, setStartTime] = useState<Date | null>(null);
   const [dueTime, setDueTime] = useState<Date | null>(null);

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -58,7 +58,7 @@ function CreatePostForm() {
       };
       mutate(payload, {
         onSuccess: (res) => {
-          console.log(res);
+          router.push(`/post/${res.data.response.id}`);
         },
         onError: (error) => {
           console.log(error);

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -14,10 +14,10 @@ function CreatePostForm() {
   const [regionIds, setRegionIds] = useState({ cityId: -1, countryId: -1, districtId: -1 });
   const [startTime, setStartTime] = useState<Date | null>(null);
   const [dueTime, setDueTime] = useState<Date | null>(null);
+  const [errMsg, setErrMsg] = useState("");
+
   const titleRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLTextAreaElement>(null);
-
-  const errRef = useRef<HTMLParagraphElement>(null);
 
   const router = useRouter();
 
@@ -27,21 +27,21 @@ function CreatePostForm() {
     const currentTime = new Date();
 
     if (titleRef.current!.value === "") {
-      errRef.current!.innerHTML = "제목을 입력해 주세요.";
+      setErrMsg("제목을 입력해 주세요.");
     } else if (titleRef.current!.value.length < 5) {
-      errRef.current!.innerHTML = "제목은 5글자 이상이어야 합니다.";
+      setErrMsg("제목은 5글자 이상이어야 합니다.");
     } else if (regionIds.districtId === -1 || regionIds.districtId === 0) {
-      errRef.current!.innerHTML = "모집 지역을 선택해 주세요.";
+      setErrMsg("모집 지역을 선택해 주세요.");
     } else if (startTime === null) {
-      errRef.current!.innerHTML = "모임 일시를 선택해 주세요.";
+      setErrMsg("모임 일시를 선택해 주세요.");
     } else if (startTime < currentTime) {
-      errRef.current!.innerHTML = "모임 일시는 과거가 될 수 없습니다.";
+      setErrMsg("모임 일시는 과거가 될 수 없습니다.");
     } else if (dueTime === null) {
-      errRef.current!.innerHTML = "마감 일시를 선택해 주세요.";
+      setErrMsg("마감 일시를 선택해 주세요.");
     } else if (dueTime < currentTime) {
-      errRef.current!.innerHTML = "마감 일시는 과거가 될 수 없습니다.";
+      setErrMsg("마감 일시는 과거가 될 수 없습니다.");
     } else if (contentRef.current!.value === "") {
-      errRef.current!.innerHTML = "내용을 입력해 주세요.";
+      setErrMsg("내용을 입력해 주세요.");
     } else {
       const payload = {
         title: titleRef.current!.value,
@@ -83,7 +83,7 @@ function CreatePostForm() {
         placeholder="내용을 입력해 주세요."
         ref={contentRef}
       />
-      <p className="mt-2 text-[#ff003e]" ref={errRef} />
+      <p className="mt-2 text-[#ff003e]">{errMsg}</p>
       <div className="flex justify-center mt-6">
         <Button styleType="thunder" rounded="full" size="lg" onClick={handleSubmit}>
           업로드

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { MdArrowBack } from "react-icons/md";
 import OptionTitle from "@/components/atoms/OptionTitle";
 import Button from "@/components/atoms/Button";
 import DatePicker from "@/components/molecules/DatePicker";
-import { useRouter } from "next/navigation";
 import DropdownBox from "@/components/molecules/DropdownBox";
 import { postRegisterPosts } from "@/apis/posts";
 import { useMutation } from "@tanstack/react-query";
@@ -20,14 +18,7 @@ function CreatePostForm() {
 
   const errRef = useRef<HTMLParagraphElement>(null);
 
-  const router = useRouter();
-
   const { mutate } = useMutation({ mutationFn: postRegisterPosts });
-
-  const handleBack = () => {
-    router.refresh();
-    router.push("/");
-  };
 
   const handleSubmit = () => {
     const currentTime = new Date();
@@ -69,7 +60,6 @@ function CreatePostForm() {
 
   return (
     <div>
-      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
       <h2 className="my-4 font-bold text-2xl">모집글 작성</h2>
       <OptionTitle>제목</OptionTitle>
       <input

--- a/src/components/organisms/PostEditForm/index.tsx
+++ b/src/components/organisms/PostEditForm/index.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { getPostById, putPost } from "@/apis/posts";
+import Button from "@/components/atoms/Button";
+import OptionTitle from "@/components/atoms/OptionTitle";
+import DatePicker from "@/components/molecules/DatePicker";
+import { formatDateToKoreanTime } from "@/utils/formatDateToString";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import React, { useRef, useState } from "react";
+
+interface Props {
+  id: string;
+}
+
+function PostEditForm({ id }: Props) {
+  const router = useRouter();
+
+  const postId = parseInt(id, 10);
+
+  const { data } = useQuery([`/api/posts${id}`, id], () => getPostById(postId), {
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
+  const post = data?.data?.response.post || {};
+
+  const { mutate } = useMutation(putPost);
+
+  const titleRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  const [startTime, setStartTime] = useState<Date>(post.startTime);
+  const [dueTime, setDueTime] = useState<Date>(post.dueTime);
+  const [errMsg, setErrMsg] = useState("");
+
+  const handleEdit = () => {
+    const currentTime = new Date();
+
+    if (titleRef.current!.value === "") {
+      setErrMsg("제목을 입력해 주세요.");
+    } else if (titleRef.current!.value.length < 5) {
+      setErrMsg("제목은 5글자 이상이어야 합니다.");
+    } else if (startTime < currentTime) {
+      setErrMsg("모임 일시는 과거가 될 수 없습니다.");
+    } else if (dueTime < currentTime) {
+      setErrMsg("마감 일시는 과거가 될 수 없습니다.");
+    } else if (contentRef.current!.value === "") {
+      setErrMsg("내용을 입력해 주세요.");
+    } else {
+      const payload = {
+        id: postId,
+        title: titleRef.current!.value,
+        startTime:
+          post.startTime === startTime
+            ? formatDateToKoreanTime(new Date(startTime))
+            : formatDateToKoreanTime(startTime),
+        dueTime: post.dueTime === dueTime ? formatDateToKoreanTime(new Date(dueTime)) : formatDateToKoreanTime(dueTime),
+        content: contentRef.current!.value,
+      };
+      mutate(payload, {
+        onSuccess: () => {
+          router.push(`/post/${id}`);
+        },
+        onError: (error) => {
+          console.log(error);
+        },
+      });
+    }
+  };
+  return (
+    <div>
+      <OptionTitle>제목</OptionTitle>
+      <input
+        type="text"
+        placeholder="제목을 입력해 주세요."
+        className="w-full py-2 px-3 rounded-lg border border-gray-400"
+        defaultValue={post.title}
+        ref={titleRef}
+      />
+      <div className="flex">
+        <DatePicker
+          title="모임"
+          value={startTime}
+          setValue={setStartTime as React.Dispatch<React.SetStateAction<Date | null>>}
+        />
+        <DatePicker
+          title="마감"
+          value={dueTime}
+          setValue={setDueTime as React.Dispatch<React.SetStateAction<Date | null>>}
+        />
+      </div>
+      <OptionTitle>내용</OptionTitle>
+      <textarea
+        className="resize-none py-2 px-3 w-full h-96 rounded-lg border border-gray-400"
+        placeholder="내용을 입력해 주세요."
+        defaultValue={post.content}
+        ref={contentRef}
+      />
+      <p className="mt-2 text-[#ff003e]">{errMsg}</p>
+      <div className="flex justify-center mt-6">
+        <Button styleType="thunder" rounded="full" size="lg" onClick={handleEdit}>
+          수정하기
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default PostEditForm;

--- a/src/components/organisms/SigninForm/index.tsx
+++ b/src/components/organisms/SigninForm/index.tsx
@@ -15,7 +15,7 @@ import { isLogin, setExpiryDate } from "@/stores/features/counterSlice";
 import { useAppDispatch } from "@/stores/hooks";
 import { postLogin } from "@/apis/sign";
 
-function SigninForm() {
+function SigninForm(): JSX.Element {
   const dispatch = useAppDispatch();
   const router = useRouter();
   const errRef = useRef<HTMLParagraphElement>(null);

--- a/src/components/organisms/SigninForm/index.tsx
+++ b/src/components/organisms/SigninForm/index.tsx
@@ -24,7 +24,7 @@ function SigninForm() {
     password: "",
   });
 
-  const handleInputChange = (fieldName: any, value: any) => {
+  const handleInputChange = (fieldName: any, value: string) => {
     setFormData((prevData) => ({
       ...prevData,
       [fieldName]: value,

--- a/src/components/organisms/SigninForm/index.tsx
+++ b/src/components/organisms/SigninForm/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import Image from "next/image";
 import Button from "@/components/atoms/Button";
 import InputBox from "@/components/molecules/InputBox";
@@ -18,11 +18,12 @@ import { postLogin } from "@/apis/sign";
 function SigninForm(): JSX.Element {
   const dispatch = useAppDispatch();
   const router = useRouter();
-  const errRef = useRef<HTMLParagraphElement>(null);
+
   const [formData, setFormData] = useState({
     email: "",
     password: "",
   });
+  const [errMsg, setErrMsg] = useState("");
 
   const handleInputChange = (fieldName: any, value: string) => {
     setFormData((prevData) => ({
@@ -33,14 +34,13 @@ function SigninForm(): JSX.Element {
 
   const handleSubmit = useCallback(async () => {
     if (!formData.email || !formData.password) {
-      errRef.current!.innerHTML = "모든 항목을 입력해주세요.";
+      setErrMsg("모든 항목을 입력해주세요.");
     } else if (!validateEmail(formData.email)) {
-      errRef.current!.innerHTML = "이메일 형식이 올바르지 않습니다.";
+      setErrMsg("이메일 형식이 올바르지 않습니다.");
     } else if (!validatePassword(formData.password)) {
-      errRef.current!.innerHTML = "비밀번호는 영문,숫자, 특수문자가 모두 포함 8자 이상 20자 이하로 입력해주세요.";
+      setErrMsg("비밀번호는 영문,숫자, 특수문자가 모두 포함 8자 이상 20자 이하로 입력해주세요.");
     } else {
       try {
-        errRef.current!.innerHTML = "";
         const response = await postLogin(formData);
         const payload = getTokenPayload(response.headers.authorization);
         // 토큰 만료시간 설정
@@ -97,7 +97,7 @@ function SigninForm(): JSX.Element {
         />
       </div>
       <div>
-        <p className="text-red-500 text-sm whitespace-pre-line" ref={errRef} />
+        <p className="text-[#ff003e] text-sm whitespace-pre-line">{errMsg}</p>
       </div>
       <BlankBar />
 

--- a/src/components/organisms/SignupForm/index.tsx
+++ b/src/components/organisms/SignupForm/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Button from "@/components/atoms/Button";
 import AuthCheckbox from "@/components/atoms/AuthCheckBox";
@@ -19,7 +19,8 @@ import { postLogin, postRegister } from "@/apis/sign";
 function SignupForm(): JSX.Element {
   const dispatch = useAppDispatch();
   const router = useRouter();
-  const errRef = useRef<HTMLParagraphElement>(null);
+
+  const [errMsg, setErrMsg] = useState("");
   const [consentChecked, setConsentChecked] = useState(false); // 동의 체크 상태
   const [confirmPassword, setConfirmPassword] = useState("");
   const [regionIds, setRegionIds] = useState({ cityId: -1, countryId: -1, districtId: -1 }); // 선택된 지역 ID
@@ -45,22 +46,21 @@ function SignupForm(): JSX.Element {
 
   const handleSubmit = useCallback(async () => {
     if (!formData.email || !formData.password || !formData.name || !confirmPassword) {
-      errRef.current!.innerHTML = "모든 항목을 입력해주세요.";
+      setErrMsg("모든 항목을 입력해주세요.");
     } else if (!validateEmail(formData.email)) {
-      errRef.current!.innerHTML = "이메일 형식이 올바르지 않습니다.";
+      setErrMsg("이메일 형식이 올바르지 않습니다.");
     } else if (!validateName(formData.name)) {
-      errRef.current!.innerHTML = "닉네임은 한글, 영문, 숫자만 가능하며 20자 이하로 입력해주세요.";
+      setErrMsg("닉네임은 한글, 영문, 숫자만 가능하며 20자 이하로 입력해주세요.");
     } else if (!validatePassword(formData.password)) {
-      errRef.current!.innerHTML = "비밀번호는 영문,숫자, 특수문자가 모두 포함 8자 이상 20자 이하로 입력해주세요.";
+      setErrMsg("비밀번호는 영문,숫자, 특수문자가 모두 포함 8자 이상 20자 이하로 입력해주세요.");
     } else if (!validatePasswordConfirm(formData.password, confirmPassword)) {
-      errRef.current!.innerHTML = "비밀번호가 일치하지 않습니다.";
+      setErrMsg("비밀번호가 일치하지 않습니다.");
     } else if (regionIds.districtId <= 0) {
-      errRef.current!.innerHTML = "읍/면/동 단위까지 지역 선택이 필요합니다.";
+      setErrMsg("읍/면/동 단위까지 지역 선택이 필요합니다.");
     } else if (!consentChecked) {
-      errRef.current!.innerHTML = "개인정보 수집 및 이용에 동의해주세요.";
+      setErrMsg("개인정보 수집 및 이용에 동의해주세요.");
     } else {
       try {
-        errRef.current!.innerHTML = "";
         await postRegister(formData);
         const response = await postLogin(formData);
         const payload = getTokenPayload(response.headers.authorization);
@@ -140,7 +140,7 @@ function SignupForm(): JSX.Element {
       </div>
 
       <div>
-        <p className=" text-red-500 text-sm whitespace-pre-line" ref={errRef} />
+        <p className="text-[#ff003e] text-sm whitespace-pre-line">{errMsg}</p>
       </div>
       <BlankBar />
 

--- a/src/components/organisms/SignupForm/index.tsx
+++ b/src/components/organisms/SignupForm/index.tsx
@@ -16,7 +16,7 @@ import { isLogin, setExpiryDate } from "@/stores/features/counterSlice";
 import { useAppDispatch } from "@/stores/hooks";
 import { postLogin, postRegister } from "@/apis/sign";
 
-function SignupForm() {
+function SignupForm(): JSX.Element {
   const dispatch = useAppDispatch();
   const router = useRouter();
   const errRef = useRef<HTMLParagraphElement>(null);

--- a/src/components/templates/ApplicantConfirmTemplate/index.tsx
+++ b/src/components/templates/ApplicantConfirmTemplate/index.tsx
@@ -9,7 +9,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
 
-function ApplicantConfirmTemplate() {
+function ApplicantConfirmTemplate(): JSX.Element {
   const pageParam = useParams();
   const postId = parseInt(pageParam.post_id as string, 10);
   const { data, isLoading, isError, error }: any = useQuery(["getApplicants", postId], {

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -31,7 +31,6 @@ function PostTemplates({ id }: Props) {
     router.refresh();
     router.push("/");
   };
-
   return (
     <div>
       <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
@@ -54,6 +53,9 @@ function PostTemplates({ id }: Props) {
           />
           <span className="ml-1">{post.userName}</span>
           <span className="ml-2 text-neutral-400 text-sm">작성시간 : {formatDateToStringByDot(post.createdAt)}</span>
+          <span className="ml-2 text-neutral-400 text-sm">
+            조회수 <strong className="font-medium text-neutral-500">{post.viewCount}</strong>
+          </span>
         </div>
         <div className="flex text-neutral-500 gap-3">
           <span className="flex items-center cursor-pointer">

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MdLocationOn, MdOutlineEdit, MdOutlineDelete, MdAlarm } from "react-icons/md";
+import { MdLocationOn, MdAlarm } from "react-icons/md";
 import { useQuery } from "@tanstack/react-query";
 import { getPostById } from "@/apis/posts";
 import Badge from "@/components/atoms/Badge";
@@ -9,6 +9,8 @@ import { formatDateToString, formatDateToStringByDot } from "@/utils/formatDateT
 import Button from "@/components/atoms/Button";
 import CommentForm from "@/components/organisms/CommentForm";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import PostEditor from "@/components/molecules/PostEditor";
+import { getCookie } from "@/utils/Cookie";
 
 interface Props {
   id: string;
@@ -16,6 +18,7 @@ interface Props {
 
 function PostTemplates({ id }: Props): JSX.Element {
   const parameter = parseInt(id, 10);
+  const userId = parseInt(getCookie("userId"), 10);
 
   const { data } = useQuery([`/api/posts${id}`, id], () => getPostById(parameter), {
     onError: (error) => {
@@ -50,16 +53,7 @@ function PostTemplates({ id }: Props): JSX.Element {
             조회수 <strong className="font-medium text-neutral-500">{post.viewCount}</strong>
           </span>
         </div>
-        <div className="flex text-neutral-500 gap-3">
-          <span className="flex items-center cursor-pointer">
-            <MdOutlineEdit />
-            수정
-          </span>
-          <span className="flex items-center cursor-pointer">
-            <MdOutlineDelete />
-            삭제
-          </span>
-        </div>
+        {userId === post.userId && <PostEditor id={parameter} />}
       </div>
       <hr className="mt-6" />
       <p className="flex mt-4 items-center gap-3">

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -6,9 +6,9 @@ import { getPostById } from "@/apis/posts";
 import Badge from "@/components/atoms/Badge";
 import Participant from "@/components/atoms/Participant";
 import { formatDateToString, formatDateToStringByDot } from "@/utils/formatDateToString";
-import Button from "@/components/atoms/Button";
 import CommentForm from "@/components/organisms/CommentForm";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import ApplyButton from "@/components/molecules/ApplyButton";
 
 interface Props {
   id: string;
@@ -72,9 +72,7 @@ function PostTemplates({ id }: Props): JSX.Element {
       </p>
       <pre className="whitespace-pre-wrap mt-4 break-all">{post.content}</pre>
       <div className="mt-4 flex flex-row-reverse">
-        <Button styleType="thunder" rounded="md" size="sm">
-          신청하기
-        </Button>
+        <ApplyButton postId={parameter} authorId={post.userId} />
       </div>
       <hr className="mt-6" />
       <CommentForm id={parameter} />

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -32,7 +32,7 @@ function PostTemplates({ id }: Props) {
         <div className="flex items-center">
           <Participant currentNumber={post.currentNumber} />
           <p className="searched-location flex items-center">
-            <MdLocationOn className="inline text-red-500" size={20} />
+            <MdLocationOn className="inline text-red-500 w-5 h-5" />
             {post.districtName}
           </p>
         </div>

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { MdArrowBack, MdLocationOn, MdOutlineEdit, MdOutlineDelete, MdAlarm } from "react-icons/md";
-import { useRouter } from "next/navigation";
+import { MdLocationOn, MdOutlineEdit, MdOutlineDelete, MdAlarm } from "react-icons/md";
 import { useQuery } from "@tanstack/react-query";
 import { getPostById } from "@/apis/posts";
 import Badge from "@/components/atoms/Badge";
@@ -16,7 +15,6 @@ interface Props {
 }
 
 function PostTemplates({ id }: Props) {
-  const router = useRouter();
   const parameter = parseInt(id, 10);
 
   const { data } = useQuery([`/api/posts${id}`, id], () => getPostById(parameter), {
@@ -27,13 +25,8 @@ function PostTemplates({ id }: Props) {
 
   const post = data?.data?.response.post || {};
 
-  const handleBack = () => {
-    router.refresh();
-    router.push("/");
-  };
   return (
     <div>
-      <MdArrowBack onClick={handleBack} size="30" className="cursor-pointer" />
       <div className="flex justify-between mt-6">
         <Badge isClose={post.isClose} />
         <div className="flex items-center">

--- a/src/components/templates/PostTemplates/index.tsx
+++ b/src/components/templates/PostTemplates/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   id: string;
 }
 
-function PostTemplates({ id }: Props) {
+function PostTemplates({ id }: Props): JSX.Element {
   const parameter = parseInt(id, 10);
 
   const { data } = useQuery([`/api/posts${id}`, id], () => getPostById(parameter), {

--- a/src/components/templates/ProfileModalTemplate/index.tsx
+++ b/src/components/templates/ProfileModalTemplate/index.tsx
@@ -10,6 +10,7 @@ function ProfileModalTemplate(): JSX.Element {
   const buttonStyle = "min-w-[150px] p-2 mx-auto flex gap-2 justify-center items-center  bg-neutral-200 rounded-full";
   const pageParam = useParams();
   const { data } = useQuery({
+    queryKey: ["userProfile", pageParam.user_id],
     queryFn: () => getProfileById(parseInt(pageParam.user_id as string, 10)),
   });
 

--- a/src/components/templates/ProfileModalTemplate/index.tsx
+++ b/src/components/templates/ProfileModalTemplate/index.tsx
@@ -2,18 +2,21 @@
 
 import { getProfileById } from "@/apis/profile";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
+import { getClientUserId } from "@/utils/Cookie";
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { MdLocationPin, MdMail, MdLeaderboard } from "react-icons/md";
 
 function ProfileModalTemplate(): JSX.Element {
   const buttonStyle = "min-w-[150px] p-2 mx-auto flex gap-2 justify-center items-center  bg-neutral-200 rounded-full";
   const pageParam = useParams();
+  const pageUserId = parseInt(pageParam.user_id as string, 10);
+  const isMyProfile = getClientUserId() === pageUserId;
   const { data } = useQuery({
-    queryKey: ["userProfile", pageParam.user_id],
-    queryFn: () => getProfileById(parseInt(pageParam.user_id as string, 10)),
+    queryKey: ["userProfile", pageUserId],
+    queryFn: () => getProfileById(pageUserId),
   });
-
+  const router = useRouter();
   const user = data?.data?.response;
 
   return (
@@ -33,19 +36,48 @@ function ProfileModalTemplate(): JSX.Element {
             <span>매너점수</span>
             <span>{`★ ${user?.rating ? `${user?.rating} / 5` : "없음"}`}</span>
           </div>
-          {/* 내 프로필이라면 내 정보 수정 페이지 Link 추가 */}
+          {isMyProfile && (
+            <div className="button_container ml-auto">
+              <button
+                type="button"
+                className="text-sm underline"
+                onClick={() => {
+                  router.push(`/close_modal`);
+                  router.refresh();
+                  router.replace(`/내정보수정페이지`);
+                }}
+              >
+                내 정보 수정
+              </button>
+            </div>
+          )}
         </div>
       </div>
       <div className="profile-modal-lower flex flex-col gap-4 p-7">
-        <button type="button" className={buttonStyle}>
+        <button
+          type="button"
+          className={buttonStyle}
+          onClick={() => {
+            router.push(`/close_modal`);
+            router.refresh();
+            router.replace(`/쪽지페이지(내쪽지함or다른사람과의쪽지페이지)`);
+          }}
+        >
           <MdMail />
-          쪽지 보내기
+          {isMyProfile ? "내 쪽지함" : "쪽지 보내기"}
         </button>
-        <button type="button" className={buttonStyle}>
+        <button
+          type="button"
+          className={buttonStyle}
+          onClick={() => {
+            router.push(`/close_modal`);
+            router.refresh();
+            router.replace(`/scoreboard/${pageUserId}`);
+          }}
+        >
           <MdLeaderboard />
           참여 기록
         </button>
-        {/* 내 프로필이라면 내 쪽지함, 참여 기록 Link로 두 버튼 대체 */}
       </div>
     </div>
   );

--- a/src/components/templates/ProfileModalTemplate/index.tsx
+++ b/src/components/templates/ProfileModalTemplate/index.tsx
@@ -9,7 +9,7 @@ import { MdLocationPin, MdMail, MdLeaderboard } from "react-icons/md";
 function ProfileModalTemplate() {
   const buttonStyle = "min-w-[150px] p-2 mx-auto flex gap-2 justify-center items-center  bg-neutral-200 rounded-full";
   const pageParam = useParams();
-  const { data, isLoading, isError } = useQuery({
+  const { data } = useQuery({
     queryFn: () => getProfileById(parseInt(pageParam.user_id as string, 10)),
   });
 

--- a/src/components/templates/ProfileModalTemplate/index.tsx
+++ b/src/components/templates/ProfileModalTemplate/index.tsx
@@ -2,7 +2,7 @@
 
 import { getProfileById } from "@/apis/profile";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
-import { getClientUserId } from "@/utils/Cookie";
+import { getCookie } from "@/utils/Cookie";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { MdLocationPin, MdMail, MdLeaderboard } from "react-icons/md";
@@ -11,7 +11,7 @@ function ProfileModalTemplate(): JSX.Element {
   const buttonStyle = "min-w-[150px] p-2 mx-auto flex gap-2 justify-center items-center  bg-neutral-200 rounded-full";
   const pageParam = useParams();
   const pageUserId = parseInt(pageParam.user_id as string, 10);
-  const isMyProfile = getClientUserId() === pageUserId;
+  const isMyProfile = getCookie("userId") === pageUserId;
   const { data } = useQuery({
     queryKey: ["userProfile", pageUserId],
     queryFn: () => getProfileById(pageUserId),

--- a/src/components/templates/ProfileModalTemplate/index.tsx
+++ b/src/components/templates/ProfileModalTemplate/index.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import { MdLocationPin, MdMail, MdLeaderboard } from "react-icons/md";
 
-function ProfileModalTemplate() {
+function ProfileModalTemplate(): JSX.Element {
   const buttonStyle = "min-w-[150px] p-2 mx-auto flex gap-2 justify-center items-center  bg-neutral-200 rounded-full";
   const pageParam = useParams();
   const { data } = useQuery({

--- a/src/components/templates/ScoreboardTemplate/index.tsx
+++ b/src/components/templates/ScoreboardTemplate/index.tsx
@@ -3,7 +3,7 @@ import RecordCard from "@/components/molecules/RecordCard";
 import RecordFilter from "@/components/molecules/RecordFilter";
 import RecordSearchBar from "@/components/molecules/RecordSearchBar";
 
-function ScoreboardTemplate() {
+function ScoreboardTemplate(): JSX.Element {
   const dummy = {
     id: 2,
     title: "오늘 7시에 부산대 락볼링장에서 게임하실분~~",

--- a/src/components/templates/ScoreboardTemplate/index.tsx
+++ b/src/components/templates/ScoreboardTemplate/index.tsx
@@ -1,5 +1,66 @@
+import RecordSummary from "@/components/atoms/RecordSummary";
+import RecordCard from "@/components/molecules/RecordCard";
+import RecordFilter from "@/components/molecules/RecordFilter";
+import RecordSearchBar from "@/components/molecules/RecordSearchBar";
+
 function ScoreboardTemplate() {
-  return <div>스코어보드템플릿</div>;
+  const dummy = {
+    id: 2,
+    title: "오늘 7시에 부산대 락볼링장에서 게임하실분~~",
+    dueTime: "2023-09-07T21:00:00",
+    districtName: "부산광역시 금정구 장전2동",
+    startTime: "2023-09-09T19:00:00",
+    currentNumber: 1,
+    isClose: true,
+    scores: [
+      {
+        id: 1,
+        score: 180,
+        scoreImage: "/score-images/1.jpg",
+      },
+      {
+        id: 2,
+        score: 210,
+        scoreImage: null,
+      },
+    ],
+    members: [
+      {
+        id: 2,
+        name: "최볼링",
+        profileImage: null,
+        isRated: true,
+      },
+      {
+        id: 3,
+        name: "이볼링",
+        profileImage: null,
+        isRated: false,
+      },
+      {
+        id: 4,
+        name: "최볼링",
+        profileImage: null,
+        isRated: true,
+      },
+      {
+        id: 1,
+        name: "김볼링",
+        profileImage: null,
+        isRated: false,
+      },
+    ],
+  };
+  return (
+    <div className="scoreboard flex flex-col gap-5">
+      <h1 className="title text-2xl">{"김볼링"}님의 기록</h1>
+      <RecordSummary game={20} average={160} maximum={180} minimum={110} />
+      <h2 className="title text-xl">참여 기록</h2>
+      <RecordFilter />
+      <RecordSearchBar />
+      <RecordCard data={dummy} />
+    </div>
+  );
 }
 
 export default ScoreboardTemplate;

--- a/src/components/templates/ScoreboardTemplate/index.tsx
+++ b/src/components/templates/ScoreboardTemplate/index.tsx
@@ -1,0 +1,5 @@
+function ScoreboardTemplate() {
+  return <div>스코어보드템플릿</div>;
+}
+
+export default ScoreboardTemplate;

--- a/src/components/templates/ScoreboardTemplate/index.tsx
+++ b/src/components/templates/ScoreboardTemplate/index.tsx
@@ -54,7 +54,7 @@ function ScoreboardTemplate() {
   return (
     <div className="scoreboard flex flex-col gap-5">
       <h1 className="title text-2xl">{"김볼링"}님의 기록</h1>
-      <RecordSummary game={20} average={160} maximum={180} minimum={110} />
+      <RecordSummary data={{ game: 20, average: 160, maximum: 180, minimum: 110 }} />
       <h2 className="title text-xl">참여 기록</h2>
       <RecordFilter />
       <RecordSearchBar />

--- a/src/hooks/useCommentsMutation.ts
+++ b/src/hooks/useCommentsMutation.ts
@@ -1,9 +1,0 @@
-import { postComments } from "@/apis/comment";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-
-export default function useCommentsMutation() {
-  const queryClient = useQueryClient();
-  const { mutate } = useMutation({ mutationFn: postComments });
-
-  return { mutate, queryClient };
-}

--- a/src/hooks/useMutateWithQueryClient.ts
+++ b/src/hooks/useMutateWithQueryClient.ts
@@ -1,0 +1,8 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export default function useMutateWithQueryClient(fetcher: (arg: any) => Promise<any>) {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({ mutationFn: fetcher });
+
+  return { mutate, queryClient };
+}

--- a/src/types/postSearchParam.ts
+++ b/src/types/postSearchParam.ts
@@ -1,0 +1,6 @@
+export interface PostSearchParam {
+  cityId?: number;
+  countryId?: number;
+  districtId?: number;
+  all?: string;
+}

--- a/src/types/postSearchParam.ts
+++ b/src/types/postSearchParam.ts
@@ -3,4 +3,6 @@ export interface PostSearchParam {
   countryId?: number;
   districtId?: number;
   all?: string;
+  key?: number;
+  size?: number;
 }

--- a/src/types/recordData.ts
+++ b/src/types/recordData.ts
@@ -1,0 +1,20 @@
+export interface RecordData {
+  id: number;
+  title: string;
+  dueTime: Date;
+  districtName: string;
+  startTime: Date;
+  currentNumber: number;
+  isClose: boolean;
+  scores: {
+    id: number;
+    score: number;
+    scoreImage: string | null;
+  }[];
+  members: {
+    id: number;
+    name: string;
+    profileImage: string | null;
+    isRated: boolean;
+  }[];
+}

--- a/src/utils/Cookie.ts
+++ b/src/utils/Cookie.ts
@@ -13,7 +13,3 @@ export const getCookie = (name: string) => {
 export const removeCookie = (name: string) => {
   cookie.remove(name, { path: "/" });
 };
-
-export const getClientUserId = () => {
-  return getCookie("userId");
-};

--- a/src/utils/Cookie.ts
+++ b/src/utils/Cookie.ts
@@ -13,3 +13,7 @@ export const getCookie = (name: string) => {
 export const removeCookie = (name: string) => {
   cookie.remove(name, { path: "/" });
 };
+
+export const getClientUserId = () => {
+  return getCookie("userId");
+};

--- a/src/utils/queryProvider.tsx
+++ b/src/utils/queryProvider.tsx
@@ -7,7 +7,7 @@ type Props = {
   children: React.ReactNode;
 };
 
-function Provider({ children }: Props) {
+function QueryProvider({ children }: Props) {
   const [client] = React.useState(
     new QueryClient({
       defaultOptions: {
@@ -23,4 +23,4 @@ function Provider({ children }: Props) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
-export default Provider;
+export default QueryProvider;

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,19 +1,26 @@
 import { removeCookie, setCookie } from "@/utils/Cookie";
 
-export const setLogin = async (email: string, token: string) => {
-  setCookie("email", email, { maxAge: 3600 * 168 });
-  setCookie("token", token, { maxAge: 3600 * 168 });
-};
-
-export const deleteToken = async () => {
-  removeCookie("email");
-  removeCookie("token");
-};
-
 export const getTokenPayload = (token: string) => {
   const Parts = token.split(".")[1];
   const decoded = atob(Parts);
   const payload = JSON.parse(decoded);
 
   return payload;
+};
+
+export const setLogin = async (email: string, token: string) => {
+  const payload = getTokenPayload(token);
+  const maxAge = 3600 * 168;
+
+  setCookie("email", email, { maxAge });
+  setCookie("token", token, { maxAge });
+  setCookie("exp", payload.exp, { maxAge });
+  setCookie("userId", payload.sub, { maxAge });
+};
+
+export const deleteToken = async () => {
+  removeCookie("email");
+  removeCookie("token");
+  removeCookie("exp");
+  removeCookie("userId");
 };


### PR DESCRIPTION
## 개요

댓글 관련 기능 구현

- 댓글 삭제 구현
삭제 버튼을 눌렀을 시 해당 댓글을 삭제 mutate함수와 invalidateQueries 사용 했습니다.
- 댓글 수정 구현
수정 버튼을 눌렀을 때 댓글 수정 폼으로 변환 update state 사용
기존 댓글을 textarea에 담게 했습니다. (resize는 3줄까지만)
수정 폼에서 버튼을 누르면 댓글을 수정 mutate함수와 invalidateQueries 사용 했습니다.
- 답글 달기 구현
댓글에서만 답글 달기가 보이게 했습니다.
답글 달기 버튼을 눌렀을 때 답글 폼으로 변환 reply state 사용했습니다.
답글 폼에서 버튼을 누르면 답글이 달림 mutate함수와 invalidateQueries 사용 했습니다.

게시글 신청 관련 기능 구현 

- 자기가 쓴 글일 때는, 참여자 확인 버튼이 보이고 다른 유저의 게시글일 경우는 신청 / 취소 버튼이 보이게 됩니다.
- 신청 기능 구현
신청 버튼을 눌렀을 때 참가 요청이 됩니다. 신청 시  invalidateQueries 사용으로 applicantId를 새로 받아오게 했습니다.
- 취소 기능 구현
신청 취소 버튼을 눌렀을 때 신청이 취소되게 했습니다.
- 참여자 확인 기능 구현
참여자 확인 버튼을 누르면 게시글 신청자들이 보이는 모달이 보입니다.

게시글 관련 기능 구현

- 자기가 쓴 글일 때만 수정 / 삭제 버튼이 보이게 했습니다.
- 게시글 수정 기능 구현
게시글 수정 버튼을 누를 시 게시글 수정 페이지로 이동하게 했습니다.
게시글의 원 데이터를 defalut value로 갖게 해서 넣어주었고, 데이터를 수정 가능하게 했습니다. (수정 후 게시글로 리다이렉트)
- 게시글 삭제 기능 구현
게시글 삭제 버튼을 누를 시 게시글 삭제를 하게 했습니다. (삭제 후 메인페이지로 리다이렉트)

참여 기록 페이지 UI 구현

- 참여 기록 페이지 UI에 사용되는 컴포넌트 구현
- 현재 기능 구현 중에 있습니다.

프로필 모달 조건부 렌더링 처리
- 자신의 프로필 모달인 경우 내 정보 수정 페이지로 이동할 수 있는 링크를 조건부 렌더랑 하도록 했습니다.
- 쪽지의 경우도 나의 쪽지함으로 이동할 수 있도록 했습니다.

모달에서 다른 URL로 이동 시 모달이 닫히지 않는 문제 해결
- 현재 프로젝트에서는 모달을 병렬 라우팅을 이용하여 구현했습니다.
- 모달에서 다른 URL로 이동 시 모달이 닫히지 않는 문제를 @modal 슬롯에서 […close_modal] catch-all 라우팅을 이용하여 해결했습니다.
- 다른 링크로 이동 시 close_modal로 router.push 후 router.refresh, 이후 원하는 경로로 router.replace하여 해결했습니다.

4, 5주차 피드백 적용 내역
- 컴포넌트의 리턴 타입 지정 - JSX.Element
- 스타일링 tailwind로 통일 - 미적용 되어 있던 부분 수정 완료
- 기타 구문 단순화 작업 완료