### PR TITLE
[Feat] 스코어 이미지 모달 구현 및 적용

### DIFF
--- a/src/components/molecules/Modal/ImageModal/index.tsx
+++ b/src/components/molecules/Modal/ImageModal/index.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import Image from "next/image";
+import ModalWrapper from "..";
+
+interface Props {
+  imagePath: string;
+  onDismiss: () => void;
+}
+
+function ImageModal({ imagePath, onDismiss }: Props) {
+  return (
+    <ModalWrapper noPadding onDismiss={onDismiss}>
+      <Image alt="스코어 이미지" src={imagePath} width={400} height={400} />
+    </ModalWrapper>
+  );
+}
+
+export default ImageModal;

--- a/src/components/molecules/RecordCard/index.tsx
+++ b/src/components/molecules/RecordCard/index.tsx
@@ -17,6 +17,7 @@ import Button from "@/components/atoms/Button";
 import RecordCardMember from "../RecordCardMember";
 import ScoreEditModal from "../Modal/ScoreEditModal";
 import StarRatingModal from "../Modal/StarRatingModal";
+import ImageModal from "../Modal/ImageModal";
 
 interface Props {
   data: RecordData;
@@ -127,16 +128,26 @@ function RecordTimeWithLocation({
 }
 
 function ScoreWithImageButton({ scoreObj }: { scoreObj: RecordData["scores"][number] }) {
+  const [imageModalOpen, setImageModalOpen] = useState(false);
   return (
     <div className="score flex gap-2">
       <span>{`스코어 | ${scoreObj.score}`}</span>
       {scoreObj.scoreImage && (
-        <Button rounded="full" size="xs" styleType="outlined-orange" fontWeight="normal">
+        <Button
+          rounded="full"
+          size="xs"
+          styleType="outlined-orange"
+          fontWeight="normal"
+          onClick={() => setImageModalOpen(true)}
+        >
           <div className="inline-flex items-center gap-x-0.5 ">
             <MdCameraAlt className="inline" />
             <span className="leading-none">이미지 보기</span>
           </div>
         </Button>
+      )}
+      {scoreObj.scoreImage && imageModalOpen && (
+        <ImageModal imagePath={scoreObj.scoreImage} onDismiss={() => setImageModalOpen(false)} />
       )}
     </div>
   );


### PR DESCRIPTION
## 개요

참여기록에 등록한 스코어 이미지를 확인할 수 있는 스코어 이미지 모달 구현을 구현하여
스코어 우측의 '이미지 보기' 버튼 클릭 시 이미지 모달이 나타나도록 기능을 구현했습니다.
parallel route 모달을 적용하려 했으나, 참여기록페이지가 searchParam에 의존하여 컴포넌트 모달로 구현하였습니다.


## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 특이사항

<!-- 있다면 작성, 없으면 지워주세요 -->
