### PR TITLE
[Feat] 볼링장 찾기 페이지 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import QueryProvider from "@/utils/providers/queryProvider";
 import RecoilRootProvider from "@/utils/providers/recoilRootProvider";
 import Toast from "@/components/molecules/Toast";
 import ProfileModal from "@/components/molecules/Modal/ProfileModal";
+import Script from "next/script";
 
 const notoSans = Noto_Sans_KR({
   weight: ["100", "300", "400", "500", "700", "900"],
@@ -15,6 +16,12 @@ const notoSans = Noto_Sans_KR({
   display: "swap",
   fallback: ["Malgun Gothic", "Roboto", "sans-serif"],
 });
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
 
 export const metadata: Metadata = {
   title: "Thunder bowling",
@@ -26,6 +33,11 @@ export default function RootLayout({ children, modal }: { children: React.ReactN
     <html lang="ko">
       <head>
         <link rel="icon" href="/favicons/favicon.ico" />
+        <Script
+          type="text/javascript"
+          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAOMAP_APPKEY}&autoload=false&libraries=services`}
+          strategy="beforeInteractive"
+        />
       </head>
 
       <body className={`bg-[#F6F6F6] ${notoSans.className}`}>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,12 @@
+import BackArrowContainer from "@/components/atoms/BackArrowContainer";
+import SearchTemplate from "@/components/templates/SearchTemplate";
+
+function SearchHome() {
+  return (
+    <BackArrowContainer>
+      <SearchTemplate />
+    </BackArrowContainer>
+  );
+}
+
+export default SearchHome;

--- a/src/components/molecules/KaKaoMap/index.tsx
+++ b/src/components/molecules/KaKaoMap/index.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { MdPlace } from "react-icons/md";
+import React, { useState, useEffect } from "react";
+import useToast from "@/hooks/useToast";
+
+interface Props {
+  place: string;
+  update: boolean;
+}
+
+function KaKaoMap({ place, update }: Props) {
+  const [location, setLocation] = useState({ latitude: 37.566826, longitude: 126.9786567 });
+  const { addWarningToast } = useToast();
+
+  function showCenterInfo(map: any) {
+    const geocoder = new window.kakao.maps.services.Geocoder();
+
+    searchAddrFromCoords(map.getCenter(), displayCenterInfo);
+
+    window.kakao.maps.event.addListener(map, "idle", function () {
+      searchAddrFromCoords(map.getCenter(), displayCenterInfo);
+    });
+
+    function searchAddrFromCoords(coords: any, callback: () => void) {
+      // 좌표로 행정동 주소 정보를 요청합니다
+      geocoder.coord2RegionCode(coords.getLng(), coords.getLat(), callback);
+    }
+
+    function displayCenterInfo(result: any, status: any) {
+      if (status === window.kakao.maps.services.Status.OK) {
+        const infoDiv = document.getElementById("centerAddr");
+
+        for (let i = 0; i < result.length; i++) {
+          // 행정동의 region_type 값은 'H' 이므로
+          if (result[i].region_type === "H") {
+            infoDiv.innerHTML = result[i].address_name;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  function showPlaceOverlay(map: any, keyword: string) {
+    const ps = new window.kakao.maps.services.Places();
+
+    ps.keywordSearch(keyword, placesSearch);
+
+    function placesSearch(data: any, status: any) {
+      if (data.length === 0) {
+        addWarningToast("검색결과가 없습니다.");
+        return;
+      }
+      if (status === window.kakao.maps.services.Status.OK) {
+        const bounds = new window.kakao.maps.LatLngBounds();
+
+        for (let i = 0; i < data.length; i++) {
+          displayMarker(data[i]);
+          bounds.extend(new window.kakao.maps.LatLng(data[i].y, data[i].x));
+        }
+
+        map.setBounds(bounds);
+      }
+    }
+
+    function displayMarker(place: any) {
+      const overlayContent = `
+        <a href=${place.place_url} target='_blank' rel='noreferrer'>
+          <div style="position: relative; padding: 5px; background-color: #fff; border: 1px solid #FE7E07; border-radius: 0.375rem; display: inline-block; cursor: pointer;">
+            ${place.place_name}
+            <div style="content: ''; position: absolute; top: 100%; left: 50%; border: 8px solid transparent; border-top-color: #FE7E07; transform: translateX(-50%);" />
+          </div>
+        </a>`;
+
+      const overlay = new window.kakao.maps.CustomOverlay({
+        map,
+        position: new window.kakao.maps.LatLng(place.y, place.x),
+        content: overlayContent,
+      });
+    }
+  }
+
+  const initializeMap = (initializeLocation: { latitude: number; longitude: number }) => {
+    if (window.kakao) {
+      window.kakao.maps.load(() => {
+        const mapContainer = document.getElementById("map");
+        const mapOption = {
+          center: new window.kakao.maps.LatLng(initializeLocation.latitude, initializeLocation.longitude),
+          level: 3,
+        };
+        const map = new window.kakao.maps.Map(mapContainer, mapOption);
+
+        const markerPosition = new window.kakao.maps.LatLng(initializeLocation.latitude, initializeLocation.longitude);
+
+        // 마커를 생성합니다
+        const marker = new window.kakao.maps.Marker({
+          position: markerPosition,
+        });
+
+        // 마커가 지도 위에 표시되도록 설정합니다
+        marker.setMap(map);
+        showCenterInfo(map);
+      });
+    }
+  };
+
+  const getLocation = () => {
+    navigator.geolocation.getCurrentPosition(
+      (pos: GeolocationPosition) => {
+        const newLocation = { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
+        setLocation(newLocation);
+        initializeMap(newLocation);
+      },
+      () => {
+        const defaultLocation = {
+          // 서울 시청
+          latitude: 37.566826, // Default latitude
+          longitude: 126.9786567, // Default longitude
+        };
+        setLocation(defaultLocation);
+        initializeMap(defaultLocation);
+      },
+      {
+        enableHighAccuracy: true,
+        maximumAge: 30000,
+        timeout: 27000,
+      },
+    );
+  };
+
+  function move() {
+    if (window.kakao) {
+      window.kakao.maps.load(() => {
+        const mapContainer = document.getElementById("map"); // 지도를 표시할 div
+        const mapOption = {
+          center: new window.kakao.maps.LatLng(location.latitude, location.longitude), // 지도의 중심좌표
+          level: 3, // 지도의 확대 레벨
+        };
+
+        // 지도를 생성합니다
+        const map = new window.kakao.maps.Map(mapContainer, mapOption);
+
+        showCenterInfo(map);
+
+        showPlaceOverlay(map, place);
+      });
+    }
+  }
+
+  useEffect(() => {
+    if (place === "") return;
+    move();
+  }, [update]);
+
+  useEffect(() => {
+    getLocation();
+  }, []);
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="ml-auto mb-4 flex items-center text-blue-600 hover:underline hover:brightness-95"
+        onClick={() => getLocation()}
+      >
+        <span className="text-lg">내위치</span>
+        <MdPlace className="w-5 h-5" />
+      </button>
+      <div id="map" className="relative w-full pb-[100%]">
+        <span id="centerAddr" className="absolute z-10 left-2 top-2 p-2 bg-white bg-opacity-75" />
+      </div>
+    </div>
+  );
+}
+export default KaKaoMap;

--- a/src/components/molecules/KaKaoMap/index.tsx
+++ b/src/components/molecules/KaKaoMap/index.tsx
@@ -11,6 +11,7 @@ interface Props {
 
 function KaKaoMap({ place, update }: Props) {
   const [location, setLocation] = useState({ latitude: 37.566826, longitude: 126.9786567 });
+  const [addrName, setAddrName] = useState("");
   const { addWarningToast } = useToast();
 
   function showCenterInfo(map: any) {
@@ -29,12 +30,10 @@ function KaKaoMap({ place, update }: Props) {
 
     function displayCenterInfo(result: any, status: any) {
       if (status === window.kakao.maps.services.Status.OK) {
-        const infoDiv = document.getElementById("centerAddr");
-
         for (let i = 0; i < result.length; i++) {
           // 행정동의 region_type 값은 'H' 이므로
           if (result[i].region_type === "H") {
-            infoDiv.innerHTML = result[i].address_name;
+            setAddrName(result[i].address_name);
             break;
           }
         }
@@ -168,7 +167,9 @@ function KaKaoMap({ place, update }: Props) {
         <MdPlace className="w-5 h-5" />
       </button>
       <div id="map" className="relative w-full pb-[100%]">
-        <span id="centerAddr" className="absolute z-10 left-2 top-2 p-2 bg-white bg-opacity-75" />
+        <span id="centerAddr" className="absolute z-10 left-2 top-2 p-2 bg-white bg-opacity-75">
+          {addrName}
+        </span>
       </div>
     </div>
   );

--- a/src/components/molecules/NavigationBar/index.tsx
+++ b/src/components/molecules/NavigationBar/index.tsx
@@ -17,7 +17,7 @@ function NavigationBar(): JSX.Element {
             <Link href="/" className="hover:underline">
               홈
             </Link>
-            <Link href="/" className="hover:underline">
+            <Link href="/search" className="hover:underline">
               볼링장 찾기
             </Link>
           </div>

--- a/src/components/templates/SearchTemplate/index.tsx
+++ b/src/components/templates/SearchTemplate/index.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import KaKaoMap from "@/components/molecules/KaKaoMap";
+import { MdSearch } from "react-icons/md";
+import React, { useRef, useState } from "react";
+import useToast from "@/hooks/useToast";
+
+function SearchTemplate() {
+  const ref = useRef<HTMLInputElement>(null);
+  const [place, setPlace] = useState("");
+  const [update, setUpdate] = useState(false);
+  const { addWarningToast } = useToast();
+
+  const handleOnClick = () => {
+    const inputValue = ref.current!.value;
+    if (inputValue === "") {
+      addWarningToast("검색어를 입력해 주세요.");
+      return;
+    }
+
+    if (inputValue.includes("볼링")) {
+      setPlace(inputValue);
+    } else {
+      setPlace(`${inputValue} 볼링장`);
+    }
+
+    setUpdate((prev) => !prev);
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center">
+        <h1 className="my-4 font-bold text-2xl">볼링장 찾기</h1>
+        <div className="flex items-center gap-2">
+          <input
+            ref={ref}
+            type="text"
+            placeholder="검색어를 입력하세요."
+            className="w-[300px] h-8 py-2 px-3 rounded-lg border border-gray-400 shadow-md"
+          />
+          <button
+            type="button"
+            className="w-8 h-8 rounded-full bg-thunder outline outline-1 outline-white shadow-xl"
+            onClick={handleOnClick}
+          >
+            <MdSearch className="w-6 h-6 text-white m-auto" />
+          </button>
+        </div>
+      </div>
+      <p className="mb-6">볼링장 이름 혹은 지역을 검색해 주세요.</p>
+      <KaKaoMap place={place} update={update} />
+    </div>
+  );
+}
+
+export default SearchTemplate;


### PR DESCRIPTION
## 개요

- 볼링장 찾기 페이지를 추가했습니다.
- 카카오map API를 이용했습니다.
- 내위치를 누를 시에 마커로 내위치를 보여줍니다.
위치 정보 얻기 실패시에 서울 시청을 보여줍니다.
- 지도 좌측 상단에 현재 위치를 보여줍니다.
- 볼링장 검색 기능을 추가했습니다.
볼링장 이름 검색 가능, 지역을 검색 할 시에 주변 볼링장을 나타냅니다. 검색 결과 없을 시에 토스트로 예외 처리 했습니다.
- 검색결과에 나타난 오버레이 클릭시 볼링장 정보를 보여주는 페이지를 새로 띄웁니다. 

Resolves: #89 

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

