### PR TITLE
[Feat] mutate 요청 에러 핸들링

### DIFF
--- a/src/components/molecules/ApplicantBlock/index.tsx
+++ b/src/components/molecules/ApplicantBlock/index.tsx
@@ -8,6 +8,7 @@ import { useCallback, useState } from "react";
 import { MdCheck, MdClose } from "react-icons/md";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { useMutation } from "@tanstack/react-query";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 
 interface Prop {
   postId: number;
@@ -18,7 +19,8 @@ function ApplicantBlock({ postId, applicantData }: Prop): JSX.Element {
   const { user, status: isAccept, id: applicantId } = applicantData;
   const [approvalStatus, setApprovalStatus] = useState(isAccept ? "accepted" : "pending");
 
-  const { addErrorToast, addSuccessToast } = useToast();
+  const { addSuccessToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const { mutate: acceptApiCall, queryClient } = useMutateWithQueryClient(putAcceptApplicant);
   const { mutate: rejectApiCall } = useMutation(deleteRejectApplicant);
@@ -32,12 +34,12 @@ function ApplicantBlock({ postId, applicantData }: Prop): JSX.Element {
           queryClient.invalidateQueries(["getApplicants", postId]);
           addSuccessToast("수락되었습니다.");
         },
-        onError: () => {
-          addErrorToast("수락 요청이 실패했습니다.");
+        onError: (err) => {
+          addApiErrorToast({ err, alt: "수락 요청이 실패했습니다." });
         },
       },
     );
-  }, [acceptApiCall, postId, applicantId, queryClient, addSuccessToast, addErrorToast]);
+  }, [acceptApiCall, postId, applicantId, queryClient, addSuccessToast, addApiErrorToast]);
 
   const handleReject = useCallback(async () => {
     rejectApiCall(
@@ -48,12 +50,12 @@ function ApplicantBlock({ postId, applicantData }: Prop): JSX.Element {
           queryClient.invalidateQueries(["getApplicants", postId]);
           addSuccessToast("거절되었습니다.");
         },
-        onError: () => {
-          addErrorToast("거절 요청이 실패했습니다.");
+        onError: (err) => {
+          addApiErrorToast({ err, alt: "거절 요청이 실패했습니다." });
         },
       },
     );
-  }, [rejectApiCall, postId, applicantId, queryClient, addSuccessToast, addErrorToast]);
+  }, [rejectApiCall, postId, applicantId, queryClient, addSuccessToast, addApiErrorToast]);
 
   return (
     <div className="applicant flex items-center justify-between border rounded-2xl py-2 px-4 md:px-2">

--- a/src/components/molecules/ApplyButton/index.tsx
+++ b/src/components/molecules/ApplyButton/index.tsx
@@ -2,6 +2,7 @@
 
 import { deleteRejectApplicant, getCheckStatus, postApply } from "@/apis/applicant";
 import Button from "@/components/atoms/Button";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import useToast from "@/hooks/useToast";
 import { getCookie } from "@/utils/Cookie";
@@ -27,6 +28,7 @@ function ApplyButton({ postId, authorId, onOpen }: Props): JSX.Element | null {
   const [isApplied, setIsApplied] = useState<boolean | null>(null);
 
   const { addSuccessToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   useEffect(() => {
     setIsApplied(data?.data?.response.isApplied);
@@ -44,8 +46,8 @@ function ApplyButton({ postId, authorId, onOpen }: Props): JSX.Element | null {
         setIsApplied(true);
         addSuccessToast("성공적으로 신청되었습니다.");
       },
-      onError: (error) => {
-        console.log(error);
+      onError: (err) => {
+        addApiErrorToast({ err, alt: "신청에 실패했습니다." });
       },
     });
   };
@@ -58,8 +60,8 @@ function ApplyButton({ postId, authorId, onOpen }: Props): JSX.Element | null {
           setIsApplied(false);
           addSuccessToast("신청이 취소되었습니다.");
         },
-        onError: (error) => {
-          console.log(error);
+        onError: (err) => {
+          addApiErrorToast({ err, alt: "취소에 실패했습니다." });
         },
       },
     );

--- a/src/components/molecules/Comment/index.tsx
+++ b/src/components/molecules/Comment/index.tsx
@@ -7,6 +7,7 @@ import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { postReply } from "@/apis/comment";
 import useToast from "@/hooks/useToast";
 import ProfileLink from "@/components/atoms/ProfileLink";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import CommentBlock from "../CommentBlock";
 import ChildComment from "../ChildComment";
 import CommentSubmit from "../CommentSubmit";
@@ -31,6 +32,7 @@ function Comment({ comment }: Props): JSX.Element {
   const { mutate, queryClient } = useMutateWithQueryClient(postReply);
 
   const { addWarningToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const handleReplyForm = () => {
     setReply((prev) => !prev);
@@ -52,8 +54,8 @@ function Comment({ comment }: Props): JSX.Element {
         queryClient.invalidateQueries(["/comments", id]);
         setReply(false);
       },
-      onError: (error) => {
-        console.log(error);
+      onError: (err) => {
+        addApiErrorToast({ err, alt: "댓글 등록에 실패했습니다." });
       },
     });
   };

--- a/src/components/molecules/CommentBlock/index.tsx
+++ b/src/components/molecules/CommentBlock/index.tsx
@@ -8,6 +8,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import useToast from "@/hooks/useToast";
 import ProfileLink from "@/components/atoms/ProfileLink";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import CommentSubmit from "../CommentSubmit";
 import ReconfirmModal from "../SemiModal/ReconfirmModal";
 
@@ -30,6 +31,7 @@ function CommentBlock({ comment, isChild, handleReplyForm }: Props): JSX.Element
   const { mutate: putMutate } = useMutation(putComments);
 
   const { addWarningToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const payload = {
     postId: id,
@@ -47,8 +49,8 @@ function CommentBlock({ comment, isChild, handleReplyForm }: Props): JSX.Element
         queryClient.invalidateQueries(["/comments", id]);
         setModalOpen(false);
       },
-      onError: (error) => {
-        console.log(error);
+      onError: (err) => {
+        addApiErrorToast({ err, alt: "댓글 삭제에 실패했습니다." });
       },
     });
   };
@@ -67,8 +69,8 @@ function CommentBlock({ comment, isChild, handleReplyForm }: Props): JSX.Element
         queryClient.invalidateQueries(["/comments", id]);
         setUpdate(false);
       },
-      onError: (error) => {
-        console.log(error);
+      onError: (err) => {
+        addApiErrorToast({ err, alt: "댓글 수정에 실패했습니다." });
       },
     });
   };

--- a/src/components/molecules/Message/index.tsx
+++ b/src/components/molecules/Message/index.tsx
@@ -8,6 +8,7 @@ import React, { useState } from "react";
 import { deleteMessages } from "@/apis/message";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { useParams } from "next/navigation";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import ReconfirmModal from "../SemiModal/ReconfirmModal";
 
 interface Props {
@@ -25,6 +26,8 @@ function Message({ message, isProfile, opponentUserName, opponentUserProfileImag
 
   const { mutate, queryClient } = useMutateWithQueryClient(deleteMessages);
 
+  const { addApiErrorToast } = useApiErrorToast();
+
   let style;
   if (message.isReceive) {
     style = "bg-[#FDAA49] rounded-br-md";
@@ -39,6 +42,9 @@ function Message({ message, isProfile, opponentUserName, opponentUserProfileImag
         onSuccess: () => {
           queryClient.invalidateQueries([`/api/messages/opponents/${id}`, id]);
           setModalOpen(false);
+        },
+        onError: (err) => {
+          addApiErrorToast({ err, alt: "메세지 삭제에 실패했습니다." });
         },
       },
     );

--- a/src/components/molecules/MessageSubmit/index.tsx
+++ b/src/components/molecules/MessageSubmit/index.tsx
@@ -2,6 +2,7 @@
 
 import { postMessages } from "@/apis/message";
 import Button from "@/components/atoms/Button";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import { useParams } from "next/navigation";
 import React, { useRef } from "react";
@@ -13,6 +14,8 @@ function MessageSubmit() {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const { mutate, queryClient } = useMutateWithQueryClient(postMessages);
+
+  const { addApiErrorToast } = useApiErrorToast();
 
   const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const textarea = e.target;
@@ -40,7 +43,7 @@ function MessageSubmit() {
         textAreaRef.current!.style.overflowY = "hidden";
       },
       onError: (err) => {
-        console.log(err);
+        addApiErrorToast({ err, alt: "메세지 전송에 실패했습니다." });
       },
     });
   };

--- a/src/components/molecules/PostEditor/index.tsx
+++ b/src/components/molecules/PostEditor/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import useToast from "@/hooks/useToast";
 import { useMutation } from "@tanstack/react-query";
 import { deletePost } from "@/apis/posts";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import ReconfirmModal from "../SemiModal/ReconfirmModal";
 
 interface Props {
@@ -17,6 +18,7 @@ function PostEditor({ id }: Props) {
 
   const { mutate } = useMutation(deletePost);
   const { addSuccessToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const handleDelete = () => {
     mutate(
@@ -27,8 +29,8 @@ function PostEditor({ id }: Props) {
           router.push("/");
           addSuccessToast("성공적으로 삭제 되었습니다.");
         },
-        onError: (error) => {
-          console.log(error);
+        onError: (err) => {
+          addApiErrorToast({ err, alt: "삭제 요청에 실패했습니다." });
         },
       },
     );

--- a/src/components/molecules/ScoreInput/index.tsx
+++ b/src/components/molecules/ScoreInput/index.tsx
@@ -7,8 +7,8 @@ import { useCallback, useRef, useState } from "react";
 import useScoreMutation from "@/hooks/useScoreMutation";
 import { UseMutationOptions, useQueryClient } from "@tanstack/react-query";
 import { MdRemoveCircleOutline, MdDeleteForever, MdCameraAlt } from "react-icons/md";
-import useToast from "@/hooks/useToast";
 import { useParams, useSearchParams } from "next/navigation";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 
 interface Props {
   postId: number;
@@ -34,7 +34,7 @@ function ScoreInput({ postId, scoreData, onRemove }: Props) {
   const { isNew } = scoreData;
   const isModified = scoreData.scoreNum !== scoreValue || scoreData.scoreImage !== selectedFile;
 
-  const { addErrorToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const handleScoreInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const scoreInputValue = parseInt(e.target.value, 10);
@@ -67,16 +67,16 @@ function ScoreInput({ postId, scoreData, onRemove }: Props) {
   interface Params {
     onSuccess?: () => void;
     onError?: () => void;
-    errorMsg?: string;
+    errorMsg: string;
   }
   const createMutationOptions = ({ onSuccess, onError, errorMsg }: Params): UseMutationOptions => ({
     onSuccess: () => {
       if (onSuccess) onSuccess();
       invalidateCurrentQuery();
     },
-    onError: () => {
+    onError: (err) => {
       if (onError) onError();
-      addErrorToast(errorMsg || "작업에 실패했습니다.");
+      addApiErrorToast({ err, alt: errorMsg });
     },
   });
 

--- a/src/components/organisms/CommentForm/index.tsx
+++ b/src/components/organisms/CommentForm/index.tsx
@@ -11,6 +11,7 @@ import useToast from "@/hooks/useToast";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
 import { getMyProfile } from "@/apis/profile";
 import { getCookie } from "@/utils/Cookie";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 
 interface Props {
   id: number;
@@ -44,6 +45,7 @@ function CommentForm({ id }: Props): JSX.Element {
   const commentRef = useRef<HTMLTextAreaElement>(null);
 
   const { addWarningToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const handleIntersect = useCallback(
     async ([entry]: IntersectionObserverEntry[], observer: IntersectionObserver) => {
@@ -76,8 +78,8 @@ function CommentForm({ id }: Props): JSX.Element {
         commentRef.current!.style.height = "40px";
         commentRef.current!.style.overflowY = "hidden";
       },
-      onError: (error) => {
-        console.log(error);
+      onError: (err) => {
+        addApiErrorToast({ err, alt: "댓글 등록에 실패했습니다." });
       },
     });
   };

--- a/src/components/organisms/CreatePostForm/index.tsx
+++ b/src/components/organisms/CreatePostForm/index.tsx
@@ -9,6 +9,7 @@ import { postRegisterPosts } from "@/apis/posts";
 import { useMutation } from "@tanstack/react-query";
 import { formatDateToKoreanTime } from "@/utils/formatDateToString";
 import { useRouter } from "next/navigation";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 
 function CreatePostForm(): JSX.Element {
   const [regionIds, setRegionIds] = useState({ cityId: -1, countryId: -1, districtId: -1 });
@@ -20,6 +21,8 @@ function CreatePostForm(): JSX.Element {
   const contentRef = useRef<HTMLTextAreaElement>(null);
 
   const router = useRouter();
+
+  const { addApiErrorToast } = useApiErrorToast();
 
   const { mutate } = useMutation({ mutationFn: postRegisterPosts });
 
@@ -54,8 +57,8 @@ function CreatePostForm(): JSX.Element {
         onSuccess: (res) => {
           router.replace(`/post/${res.data.response.id}`);
         },
-        onError: (error) => {
-          console.log(error);
+        onError: (err) => {
+          addApiErrorToast({ err, alt: "글 작성에 실패했습니다." });
         },
       });
     }

--- a/src/components/organisms/MessageRoomList/index.tsx
+++ b/src/components/organisms/MessageRoomList/index.tsx
@@ -4,6 +4,7 @@ import { deleteMessageCard, getMessages } from "@/apis/message";
 import Button from "@/components/atoms/Button";
 import MessageCard from "@/components/molecules/MessageCard";
 import UserSearchModal from "@/components/molecules/Modal/UserSearchModal";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import useToast from "@/hooks/useToast";
@@ -16,6 +17,7 @@ function MessageRoomList(): JSX.Element {
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
 
   const { addSuccessToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
     ["/api/messages/opponents"],
@@ -56,7 +58,9 @@ function MessageRoomList(): JSX.Element {
             setCheckList([]);
             addSuccessToast("성공적으로 삭제되었습니다.");
           },
-          onError: () => {},
+          onError: (err) => {
+            addApiErrorToast({ err, alt: "삭제에 실패했습니다." });
+          },
         },
       );
     });

--- a/src/components/organisms/PostEditForm/index.tsx
+++ b/src/components/organisms/PostEditForm/index.tsx
@@ -5,6 +5,7 @@ import Button from "@/components/atoms/Button";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import OptionTitle from "@/components/atoms/OptionTitle";
 import DatePicker from "@/components/molecules/DatePicker";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import { formatDateToKoreanTime } from "@/utils/formatDateToString";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -18,6 +19,8 @@ function PostEditForm({ id }: Props) {
   const router = useRouter();
 
   const postId = parseInt(id, 10);
+
+  const { addApiErrorToast } = useApiErrorToast();
 
   const { data, isLoading } = useQuery([`/api/posts${id}`, id], () => getPostById(postId), {
     onError: (error) => {
@@ -64,8 +67,8 @@ function PostEditForm({ id }: Props) {
         onSuccess: () => {
           router.back();
         },
-        onError: (error) => {
-          console.log(error);
+        onError: (err) => {
+          addApiErrorToast({ err, alt: "글 수정에 실패했습니다." });
         },
       });
     }

--- a/src/components/organisms/SigninForm/index.tsx
+++ b/src/components/organisms/SigninForm/index.tsx
@@ -13,6 +13,8 @@ import { validateEmail, validatePassword } from "@/utils/validation";
 import { setLogin } from "@/utils/user";
 import { postLogin } from "@/apis/sign";
 import { useMutation } from "@tanstack/react-query";
+import useToast from "@/hooks/useToast";
+import getApiErrorMsg from "@/utils/getApiErrorMsg";
 
 function SigninForm(): JSX.Element {
   const router = useRouter();
@@ -22,6 +24,8 @@ function SigninForm(): JSX.Element {
     password: "",
   });
   const [errMsg, setErrMsg] = useState("");
+
+  const { addErrorToast } = useToast();
 
   const { mutate } = useMutation(postLogin);
 
@@ -47,11 +51,13 @@ function SigninForm(): JSX.Element {
           router.refresh();
         },
         onError: (err) => {
-          console.log(err);
+          const errorMessage = getApiErrorMsg(err);
+          if (errorMessage) addErrorToast(errorMessage);
+          else addErrorToast("회원가입 요청이 실패했습니다.");
         },
       });
     }
-  }, [formData, router, mutate]);
+  }, [formData, mutate, router, addErrorToast]);
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {

--- a/src/components/organisms/SigninForm/index.tsx
+++ b/src/components/organisms/SigninForm/index.tsx
@@ -13,8 +13,7 @@ import { validateEmail, validatePassword } from "@/utils/validation";
 import { setLogin } from "@/utils/user";
 import { postLogin } from "@/apis/sign";
 import { useMutation } from "@tanstack/react-query";
-import useToast from "@/hooks/useToast";
-import getApiErrorMsg from "@/utils/getApiErrorMsg";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 
 function SigninForm(): JSX.Element {
   const router = useRouter();
@@ -25,7 +24,7 @@ function SigninForm(): JSX.Element {
   });
   const [errMsg, setErrMsg] = useState("");
 
-  const { addErrorToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const { mutate } = useMutation(postLogin);
 
@@ -51,13 +50,11 @@ function SigninForm(): JSX.Element {
           router.refresh();
         },
         onError: (err) => {
-          const errorMessage = getApiErrorMsg(err);
-          if (errorMessage) addErrorToast(errorMessage);
-          else addErrorToast("회원가입 요청이 실패했습니다.");
+          addApiErrorToast({ err, alt: "회원가입 요청이 실패했습니다." });
         },
       });
     }
-  }, [formData, mutate, router, addErrorToast]);
+  }, [formData, mutate, router, addApiErrorToast]);
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {

--- a/src/components/organisms/SignupForm/index.tsx
+++ b/src/components/organisms/SignupForm/index.tsx
@@ -15,11 +15,12 @@ import { postLogin, postRegister } from "@/apis/sign";
 import { useMutation } from "@tanstack/react-query";
 import useToast from "@/hooks/useToast";
 import { setLogin } from "@/utils/user";
-import getApiErrorMsg from "@/utils/getApiErrorMsg";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 
 function SignupForm(): JSX.Element {
   const router = useRouter();
-  const { addSuccessToast, addWarningToast, addErrorToast } = useToast();
+  const { addSuccessToast, addWarningToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
 
   const [errMsg, setErrMsg] = useState("");
   const [consentChecked, setConsentChecked] = useState(false); // 동의 체크 상태
@@ -83,9 +84,7 @@ function SignupForm(): JSX.Element {
           callPostLogin(formData);
         },
         onError: (err) => {
-          const errorMessage = getApiErrorMsg(err);
-          if (errorMessage) addErrorToast(errorMessage);
-          else addErrorToast("회원가입 요청이 실패했습니다.");
+          addApiErrorToast({ err, alt: "회원가입 요청이 실패했습니다." });
         },
       });
     }
@@ -98,7 +97,7 @@ function SignupForm(): JSX.Element {
     addSuccessToast,
     router,
     callPostLogin,
-    addErrorToast,
+    addApiErrorToast,
   ]);
 
   useEffect(() => {

--- a/src/components/organisms/SignupForm/index.tsx
+++ b/src/components/organisms/SignupForm/index.tsx
@@ -15,10 +15,11 @@ import { postLogin, postRegister } from "@/apis/sign";
 import { useMutation } from "@tanstack/react-query";
 import useToast from "@/hooks/useToast";
 import { setLogin } from "@/utils/user";
+import getApiErrorMsg from "@/utils/getApiErrorMsg";
 
 function SignupForm(): JSX.Element {
   const router = useRouter();
-  const { addSuccessToast, addWarningToast } = useToast();
+  const { addSuccessToast, addWarningToast, addErrorToast } = useToast();
 
   const [errMsg, setErrMsg] = useState("");
   const [consentChecked, setConsentChecked] = useState(false); // 동의 체크 상태
@@ -82,11 +83,23 @@ function SignupForm(): JSX.Element {
           callPostLogin(formData);
         },
         onError: (err) => {
-          console.log(err);
+          const errorMessage = getApiErrorMsg(err);
+          if (errorMessage) addErrorToast(errorMessage);
+          else addErrorToast("회원가입 요청이 실패했습니다.");
         },
       });
     }
-  }, [confirmPassword, consentChecked, formData, regionIds.districtId, router, mutate]);
+  }, [
+    formData,
+    confirmPassword,
+    regionIds.districtId,
+    consentChecked,
+    mutate,
+    addSuccessToast,
+    router,
+    callPostLogin,
+    addErrorToast,
+  ]);
 
   useEffect(() => {
     handleInputChange("districtId", regionIds.districtId);

--- a/src/components/templates/ApplicantConfirmTemplate/index.tsx
+++ b/src/components/templates/ApplicantConfirmTemplate/index.tsx
@@ -4,6 +4,7 @@ import { getApplicants } from "@/apis/applicant";
 import { patchPost } from "@/apis/posts";
 import Button from "@/components/atoms/Button";
 import ApplicantBlock from "@/components/molecules/ApplicantBlock";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import useToast from "@/hooks/useToast";
 import { Applicant } from "@/types/applicant";
@@ -47,11 +48,12 @@ function ApplicantConfirmTemplate({ postId }: Props): JSX.Element {
     });
   }, [errorComponent, isError, noApplicantComponent, postId, response?.applicants, response?.applicantNumber]);
 
-  const { addErrorToast, addSuccessToast } = useToast();
+  const { addSuccessToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
   const { mutate: handleClose, queryClient } = useMutateWithQueryClient(patchPost);
   const mutateOption = {
-    onError: () => {
-      addErrorToast("요청에 실패했습니다. 다시 시도해주세요");
+    onError: (err: unknown) => {
+      addApiErrorToast({ err, alt: "요청에 실패했습니다. 다시 시도해주세요" });
     },
     onSuccess: () => {
       queryClient.invalidateQueries([`/api/posts/${postId}`, postId]);

--- a/src/components/templates/MyPageTemplate/index.tsx
+++ b/src/components/templates/MyPageTemplate/index.tsx
@@ -5,6 +5,7 @@ import { getMyProfile, putProfile } from "@/apis/profile";
 import Button from "@/components/atoms/Button";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
 import DropdownBox from "@/components/molecules/DropdownBox";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import useToast from "@/hooks/useToast";
 import { validateName } from "@/utils/validation";
@@ -51,6 +52,7 @@ function MyPageTemplate() {
   };
 
   const { addErrorToast, addSuccessToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
   const { mutate: putCurrentProfile, queryClient } = useMutateWithQueryClient(putProfile);
   const mutateOption: MutateOptions = {
     onSuccess: () => {
@@ -58,9 +60,7 @@ function MyPageTemplate() {
       queryClient.invalidateQueries(["/api/users/mine"]);
     },
     onError: (err: any) => {
-      const statusCode = err.response?.data?.status;
-      if (statusCode === 500) addErrorToast("이미 존재하는 닉네임입니다.");
-      else addErrorToast("저장에 실패했습니다");
+      addApiErrorToast({ err, alt: "프로필 수정에 실패했습니다." });
     },
   };
   const handleOnSubmit = () => {

--- a/src/components/templates/StarRatingTemplate/index.tsx
+++ b/src/components/templates/StarRatingTemplate/index.tsx
@@ -4,6 +4,7 @@ import { getProfileById } from "@/apis/profile";
 import postRating from "@/apis/rating";
 import CircularProfileImage from "@/components/atoms/CircularProfileImage";
 import StarButtons from "@/components/atoms/StarButtons";
+import useApiErrorToast from "@/hooks/useApiErrorToast";
 import useMutateWithQueryClient from "@/hooks/useMutateWithQueryClient";
 import useToast from "@/hooks/useToast";
 import { StarRatingModalProps } from "@/types/starRatingModalProps";
@@ -21,7 +22,8 @@ function StarRatingTemplate({ postId, applicantId, targetId, onDismiss }: StarRa
   const userName = data?.data?.response?.name;
   const userImage = data?.data?.response?.profileImage;
 
-  const { addErrorToast, addSuccessToast } = useToast();
+  const { addSuccessToast } = useToast();
+  const { addApiErrorToast } = useApiErrorToast();
   const { mutate: postStarRating, queryClient } = useMutateWithQueryClient(postRating);
   const mutateOption = {
     onSuccess: () => {
@@ -29,8 +31,8 @@ function StarRatingTemplate({ postId, applicantId, targetId, onDismiss }: StarRa
       addSuccessToast("등록이 완료되었습니다.");
       onDismiss();
     },
-    onError: () => {
-      addErrorToast("요청이 실패하였습니다.");
+    onError: (err: unknown) => {
+      addApiErrorToast({ err, alt: "별점 등록이 실패하였습니다." });
     },
   };
 

--- a/src/hooks/useApiErrorToast.ts
+++ b/src/hooks/useApiErrorToast.ts
@@ -6,9 +6,13 @@ interface Param {
   alt: string;
 }
 
-export default function useApiErrorToast({ err, alt }: Param) {
+export default function useApiErrorToast() {
   const { addErrorToast } = useToast();
-  const errorMessage = getApiErrorMsg(err);
-  if (errorMessage) addErrorToast(errorMessage);
-  else addErrorToast(alt);
+  const addApiErrorToast = ({ err, alt }: Param) => {
+    const errorMessage = getApiErrorMsg(err);
+    if (errorMessage) addErrorToast(errorMessage);
+    else addErrorToast(alt);
+  };
+
+  return { addApiErrorToast };
 }

--- a/src/hooks/useApiErrorToast.ts
+++ b/src/hooks/useApiErrorToast.ts
@@ -1,0 +1,14 @@
+import getApiErrorMsg from "@/utils/getApiErrorMsg";
+import useToast from "./useToast";
+
+interface Param {
+  err: unknown;
+  alt: string;
+}
+
+export default function useApiErrorToast({ err, alt }: Param) {
+  const { addErrorToast } = useToast();
+  const errorMessage = getApiErrorMsg(err);
+  if (errorMessage) addErrorToast(errorMessage);
+  else addErrorToast(alt);
+}

--- a/src/utils/getApiErrorMsg.ts
+++ b/src/utils/getApiErrorMsg.ts
@@ -1,0 +1,3 @@
+export default function getApiErrorMsg(err: unknown) {
+  return err.response?.data?.errorMessage;
+}

--- a/src/utils/getApiErrorMsg.ts
+++ b/src/utils/getApiErrorMsg.ts
@@ -1,3 +1,4 @@
 export default function getApiErrorMsg(err: unknown) {
-  return err.response?.data?.errorMessage;
+  const error = err as any;
+  return error.response?.data?.errorMessage;
 }


### PR DESCRIPTION
## 개요

### mutate 요청 에러 핸들링
get 요청을 제외한 api 요청에 대해 예외 처리를 했다.
- 유틸 함수 getApiErrorMsg 정의
  - 에러 객체를 전달 받아 api 응답으로 온 errorMsg를 전달한다.
- 커스텀 훅 useApiErrorToast 구현
  - 에러 객체와, 대체 텍스트를 전달받아 에러 토스트를 보여주는 addApiErrorToast 함수를 리턴한다.
-  get 요청을 제외한 api 요청에 대한 예외 처리를 진행
  - 특이사항 : (예외처리가 되지 않은 부분)
    - 로그아웃 - api가 사용된 곳이 없음
    - 토큰 재발급 - 예외처리 하는 것이 더 이상할 것 같아 현행 유지(인터셉터에서 훅도 사용 불가)
    - 비밀번호 찾기 - 프론트에서 구현되어 있지 않음
    - 비밀번호 변경 - 프론트에서 구현되어 있지 않음


## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
